### PR TITLE
feat: add `kidkazz distill` command for agent skill generation

### DIFF
--- a/src/cli/commands/distill.py
+++ b/src/cli/commands/distill.py
@@ -18,6 +18,13 @@ app = typer.Typer(help="Distill textbook knowledge into specialist agent configs
 DISTILL_DIR = Path.home() / ".kidkazz" / "distilled"
 
 
+def _safe_filename(doc_id: str) -> str:
+    """Sanitize doc_id for safe use in filenames (prevent path traversal)."""
+    import re
+
+    return re.sub(r"[^\w\-]", "_", doc_id)[:100]
+
+
 @app.command("generate")
 def generate(
     doc_id: str = typer.Argument(help="Document ID to distill"),
@@ -58,7 +65,7 @@ def generate(
     store = get_store(config)
 
     try:
-        from src.distiller.distiller import TextbookDistiller
+        from ...distiller.distiller import TextbookDistiller
     except ImportError as e:
         print_error(f"Missing dependency: {e}")
         print_warning("Install with: pip install 'kidkazz[concepts]'")
@@ -67,6 +74,10 @@ def generate(
     try:
         distiller = TextbookDistiller(store, provider=provider)
         result = distiller.distill(doc_id, top_k=top_k, num_examples=num_examples)
+    except ImportError as e:
+        print_error(f"Missing dependency: {e}")
+        print_warning("Install with: pip install 'kidkazz[concepts]'")
+        raise typer.Exit(1)
     except ValueError as e:
         print_error(str(e))
         raise typer.Exit(1)
@@ -75,7 +86,8 @@ def generate(
         raise typer.Exit(1)
 
     # Write output file
-    output_path = output or (DISTILL_DIR / f"{doc_id}_agent.json")
+    safe_name = _safe_filename(doc_id)
+    output_path = output or (DISTILL_DIR / f"{safe_name}_agent.json")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(result, indent=2, ensure_ascii=False))
 
@@ -91,14 +103,19 @@ def show(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
 ) -> None:
     """Show an existing distilled agent config."""
-    path = DISTILL_DIR / f"{doc_id}_agent.json"
+    safe_name = _safe_filename(doc_id)
+    path = DISTILL_DIR / f"{safe_name}_agent.json"
 
     if not path.exists():
         print_error(f"No distilled config found for '{doc_id}'")
         print_warning(f"Run: kidkazz distill generate {doc_id}")
         raise typer.Exit(1)
 
-    data = json.loads(path.read_text())
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print_error(f"Corrupt config file {path}: {e}")
+        raise typer.Exit(1)
 
     if json_output:
         print_json(data)

--- a/src/cli/commands/distill.py
+++ b/src/cli/commands/distill.py
@@ -1,0 +1,204 @@
+"""CLI commands for distilling textbook knowledge into agent configs."""
+
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from ..config import CLIConfig
+from ..output import console, print_error, print_json, print_success, print_warning
+from ..utils import get_store
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(help="Distill textbook knowledge into specialist agent configs")
+
+DISTILL_DIR = Path.home() / ".kidkazz" / "distilled"
+
+
+@app.command("generate")
+def generate(
+    doc_id: str = typer.Argument(help="Document ID to distill"),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output file path (default: ~/.kidkazz/distilled/<doc_id>_agent.json)",
+    ),
+    provider: str = typer.Option(
+        "openai/gpt-4o-mini",
+        "--provider",
+        "-p",
+        help="LLM provider for generation (e.g., openai/gpt-4o-mini)",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Print raw JSON to stdout",
+    ),
+    top_k: int = typer.Option(
+        20,
+        "--top-k",
+        help="Number of top concepts to include in expertise",
+    ),
+    num_examples: int = typer.Option(
+        5,
+        "--examples",
+        help="Number of few-shot tool usage examples to generate",
+    ),
+) -> None:
+    """Distill a document's knowledge base into an AgentConfig JSON for agent_ex.
+
+    Reads concept graph + chapter summaries from Helix-DB and produces a
+    specialist agent configuration that agent_ex can import. Uses 2 LLM calls.
+    """
+    config = CLIConfig.load()
+    store = get_store(config)
+
+    try:
+        from src.distiller.distiller import TextbookDistiller
+    except ImportError as e:
+        print_error(f"Missing dependency: {e}")
+        print_warning("Install with: pip install 'kidkazz[concepts]'")
+        raise typer.Exit(1)
+
+    try:
+        distiller = TextbookDistiller(store, provider=provider)
+        result = distiller.distill(doc_id, top_k=top_k, num_examples=num_examples)
+    except ValueError as e:
+        print_error(str(e))
+        raise typer.Exit(1)
+    except Exception as e:
+        print_error(f"Distillation failed: {e}")
+        raise typer.Exit(1)
+
+    # Write output file
+    output_path = output or (DISTILL_DIR / f"{doc_id}_agent.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result, indent=2, ensure_ascii=False))
+
+    if json_output:
+        print_json(result)
+    else:
+        _print_summary(result, output_path)
+
+
+@app.command("show")
+def show(
+    doc_id: str = typer.Argument(help="Document ID"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """Show an existing distilled agent config."""
+    path = DISTILL_DIR / f"{doc_id}_agent.json"
+
+    if not path.exists():
+        print_error(f"No distilled config found for '{doc_id}'")
+        print_warning(f"Run: kidkazz distill generate {doc_id}")
+        raise typer.Exit(1)
+
+    data = json.loads(path.read_text())
+
+    if json_output:
+        print_json(data)
+    else:
+        _print_summary(data, path)
+
+
+@app.command("list")
+def list_distilled(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+) -> None:
+    """List all distilled agent configs."""
+    if not DISTILL_DIR.exists():
+        print_warning("No distilled configs found.")
+        return
+
+    configs = []
+    for path in sorted(DISTILL_DIR.glob("*_agent.json")):
+        try:
+            data = json.loads(path.read_text())
+            meta = data.get("_distill_metadata", {})
+            configs.append({
+                "name": data.get("name", ""),
+                "source_doc_id": meta.get("source_document_id", ""),
+                "total_concepts": meta.get("total_concepts", 0),
+                "total_chapters": meta.get("total_chapters", 0),
+                "distilled_at": meta.get("distilled_at", ""),
+                "file": str(path),
+            })
+        except (json.JSONDecodeError, KeyError):
+            continue
+
+    if json_output:
+        print_json(configs)
+        return
+
+    if not configs:
+        print_warning("No distilled configs found.")
+        return
+
+    from rich.table import Table
+
+    table = Table(title="Distilled Agent Configs", show_header=True, header_style="bold cyan")
+    table.add_column("Name", style="cyan")
+    table.add_column("Source Doc", style="yellow")
+    table.add_column("Concepts", justify="right")
+    table.add_column("Chapters", justify="right")
+    table.add_column("Distilled At", style="dim")
+
+    for c in configs:
+        table.add_row(
+            c["name"],
+            c["source_doc_id"],
+            str(c["total_concepts"]),
+            str(c["total_chapters"]),
+            c["distilled_at"],
+        )
+
+    console.print(table)
+
+
+def _print_summary(data: dict, output_path: Path) -> None:
+    """Print a formatted summary of a distilled config."""
+    from rich.panel import Panel
+    from rich.table import Table
+
+    meta = data.get("_distill_metadata", {})
+
+    # Header
+    console.print()
+    console.print(Panel(
+        f"[bold]{data.get('name', 'unknown')}[/bold]\n"
+        f"{data.get('description', '')}",
+        title="Distilled Agent Config",
+        border_style="green",
+    ))
+
+    # Stats
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="bold")
+    table.add_column("Value")
+    table.add_row("Role", data.get("role", ""))
+    table.add_row("Personality", data.get("personality", ""))
+    table.add_row("Expertise", ", ".join(data.get("expertise", [])[:5]))
+    table.add_row("Tools", str(len(data.get("tool_ids", []))))
+    table.add_row("Examples", str(len(data.get("tool_examples", []))))
+    table.add_row("Concepts", str(meta.get("total_concepts", 0)))
+    table.add_row("Chapters", str(meta.get("total_chapters", 0)))
+    table.add_row("Prerequisites", str(len(meta.get("prerequisite_skills", []))))
+    console.print(table)
+
+    # Concept type distribution
+    type_dist = meta.get("concept_types", {})
+    if type_dist:
+        top_types = list(type_dist.items())[:5]
+        console.print(
+            f"\n[dim]Concept types: "
+            + ", ".join(f"{t}: {c}" for t, c in top_types)
+            + "[/dim]"
+        )
+
+    console.print()
+    print_success(f"Saved to: {output_path}")

--- a/src/cli/commands/distill.py
+++ b/src/cli/commands/distill.py
@@ -212,7 +212,7 @@ def _print_summary(data: dict, output_path: Path) -> None:
     if type_dist:
         top_types = list(type_dist.items())[:5]
         console.print(
-            f"\n[dim]Concept types: "
+            "\n[dim]Concept types: "
             + ", ".join(f"{t}: {c}" for t, c in top_types)
             + "[/dim]"
         )

--- a/src/cli/commands/distill.py
+++ b/src/cli/commands/distill.py
@@ -145,7 +145,7 @@ def list_distilled(
                 "distilled_at": meta.get("distilled_at", ""),
                 "file": str(path),
             })
-        except (json.JSONDecodeError, KeyError):
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             continue
 
     if json_output:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import typer
 
-from .commands import concepts, config_cmd, db, docs, inbox, ingest, search, summarize
+from .commands import concepts, config_cmd, db, distill, docs, inbox, ingest, search, summarize
 
 # Create main app
 app = typer.Typer(
@@ -26,6 +26,7 @@ app.add_typer(config_cmd.app, name="config", help="Configuration management")
 app.add_typer(inbox.app, name="inbox", help="Manage PDF inbox")
 app.add_typer(concepts.app, name="concepts", help="Concept extraction and management")
 app.add_typer(summarize.app, name="summarize", help="Document summarization")
+app.add_typer(distill.app, name="distill", help="Distill textbooks into agent configs")
 
 
 @app.callback()

--- a/src/distiller/__init__.py
+++ b/src/distiller/__init__.py
@@ -1,0 +1,1 @@
+"""Textbook knowledge distillation into specialist agent configs."""

--- a/src/distiller/distiller.py
+++ b/src/distiller/distiller.py
@@ -131,14 +131,20 @@ class TextbookDistiller:
     """
 
     def __init__(self, store: Any, provider: str = "openai/gpt-4o-mini"):
+        self.store = store
+        self.provider = provider
+        self.client = None
+
+    def _ensure_instructor(self) -> None:
+        """Lazily initialize the instructor client, raising on missing dep."""
+        if self.client is not None:
+            return
         if not INSTRUCTOR_AVAILABLE or instructor is None:
             raise ImportError(
                 "instructor is not installed. "
                 "Install with: pip install 'kidkazz[concepts]'"
             )
-        self.store = store
-        self.provider = provider
-        self.client = instructor.from_provider(provider)
+        self.client = instructor.from_provider(self.provider)
 
     # ------------------------------------------------------------------
     # Main entry point
@@ -181,6 +187,8 @@ class TextbookDistiller:
             len(concepts),
             len(chapter_summaries),
         )
+
+        self._ensure_instructor()
 
         # 2. Generate identity (LLM call 1)
         identity = self._generate_identity(
@@ -235,27 +243,40 @@ class TextbookDistiller:
         """Rank concepts by connection count (most connected = most important).
 
         For each concept, queries related concepts and counts connections.
-        Falls back to alphabetical sort if no connections can be queried.
+        Caches the related data in ``_related`` so ``_build_prerequisites``
+        can reuse it without re-querying.
         """
         ranked = []
+        skipped = 0
         for concept in concepts:
             concept_id = concept.get("concept_id", "")
             if not concept_id:
+                skipped += 1
                 continue
 
             try:
                 related = self.store.get_related_concepts_with_types(concept_id)
-                connection_count = len(related)
             except Exception:
-                connection_count = 0
+                related = []
 
-            ranked.append({**concept, "_connection_count": connection_count})
+            ranked.append({
+                **concept,
+                "_connection_count": len(related),
+                "_related": related,
+            })
+
+        if skipped:
+            logger.warning("Skipped %d concepts with missing concept_id", skipped)
 
         ranked.sort(key=lambda c: c.get("_connection_count", 0), reverse=True)
         return ranked[:top_k]
 
     def _build_prerequisites(self, ranked_concepts: list[dict]) -> list[dict]:
-        """Build prerequisite chains from 'requires'/'calculated_from' edges."""
+        """Build prerequisite chains from 'requires'/'calculated_from' edges.
+
+        Uses cached ``_related`` data from ``_rank_concepts`` to avoid
+        redundant store queries.
+        """
         prerequisites = []
         prerequisite_types = {"requires", "calculated_from"}
 
@@ -264,10 +285,7 @@ class TextbookDistiller:
             if not concept_id:
                 continue
 
-            try:
-                related = self.store.get_related_concepts_with_types(concept_id)
-            except Exception:
-                continue
+            related = concept.get("_related", [])
 
             deps = [
                 r["concept"].get("name", r["concept"].get("concept_id", ""))
@@ -468,8 +486,8 @@ Each example should show realistic tool_calls with actual argument values."""
                 "- [concept_2]: [brief relevance]"
             ),
             "system_prompt": None,
-            "provider": "openai",
-            "model": "gpt-4o-mini",
+            "provider": self.provider.split("/")[0] if "/" in self.provider else "openai",
+            "model": self.provider.split("/", 1)[1] if "/" in self.provider else self.provider,
             "disabled_builtins": [],
             "intervention_pipeline": [],
             "sandbox": {},
@@ -500,4 +518,10 @@ def _slugify(text: str) -> str:
     text = text.lower().strip()
     text = re.sub(r"[^\w\s-]", "", text)
     text = re.sub(r"[\s_-]+", "_", text)
-    return text.strip("_")[:80]
+    result = text.strip("_")[:80]
+    return result or "unnamed"
+
+
+def _sanitize_filename(doc_id: str) -> str:
+    """Sanitize a doc_id for use in a filename (prevent path traversal)."""
+    return re.sub(r"[^\w\-]", "_", doc_id)[:100]

--- a/src/distiller/distiller.py
+++ b/src/distiller/distiller.py
@@ -166,6 +166,11 @@ class TextbookDistiller:
         Returns:
             Dict matching agent_ex AgentConfig fields + _distill_metadata
         """
+        if top_k < 1:
+            raise ValueError("top_k must be a positive integer")
+        if num_examples < 1:
+            raise ValueError("num_examples must be a positive integer")
+
         logger.info("Gathering document data for %s...", doc_id)
 
         # 1. Gather data (no LLM)
@@ -256,7 +261,8 @@ class TextbookDistiller:
 
             try:
                 related = self.store.get_related_concepts_with_types(concept_id)
-            except Exception:
+            except Exception as e:
+                logger.warning("Failed to get related concepts for %s: %s", concept_id, e)
                 related = []
 
             ranked.append({

--- a/src/distiller/distiller.py
+++ b/src/distiller/distiller.py
@@ -1,0 +1,503 @@
+"""Distill textbook knowledge into specialist agent configs for agent_ex.
+
+Reads a document's concept graph + chapter summaries from Helix-DB and produces
+an AgentConfig-compatible JSON that agent_ex can import as a specialist agent.
+
+The specialist agent uses kidkazz_rag's MCP tools at runtime to answer domain
+questions grounded in textbook content.
+"""
+
+import json
+import logging
+import re
+import time
+from collections import Counter
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Optional instructor import (same pattern as summarizer.py)
+# ---------------------------------------------------------------------------
+try:
+    import instructor
+
+    INSTRUCTOR_AVAILABLE = True
+except ImportError:
+    instructor = None  # type: ignore[assignment]
+    INSTRUCTOR_AVAILABLE = False
+
+# ---------------------------------------------------------------------------
+# Pydantic models for structured LLM output
+# ---------------------------------------------------------------------------
+
+
+class AgentIdentity(BaseModel):
+    """LLM-generated agent identity fields."""
+
+    role: str = Field(description="One-sentence role description starting with 'an expert in...'")
+    personality: str = Field(
+        description="Communication style in 2-5 words (e.g., 'precise and pedagogical')"
+    )
+    goal: str = Field(description="2-3 sentence goal describing what the agent helps users do")
+    success_criteria: str = Field(description="1-2 sentence criteria for a good answer")
+    constraints: list[str] = Field(
+        description="3-6 rules the agent must follow (cite sources, handle uncertainty, etc.)"
+    )
+    scope: str = Field(description="One sentence describing the agent's knowledge boundary")
+    tool_guidance: str = Field(
+        description="Markdown-formatted guide for when/how to use each MCP tool"
+    )
+
+
+class ToolCall(BaseModel):
+    """A single tool call in a few-shot example."""
+
+    tool: str = Field(description="MCP tool name")
+    args: dict[str, Any] = Field(description="Tool arguments")
+
+
+class ToolExample(BaseModel):
+    """A few-shot example showing how to use MCP tools."""
+
+    user: str = Field(description="User question")
+    assistant_thinking: str = Field(description="Brief reasoning about which tools to use")
+    tool_calls: list[ToolCall] = Field(description="Ordered list of tool calls")
+    response_sketch: str = Field(description="Brief sketch of what the response would contain")
+
+
+class ToolExampleSet(BaseModel):
+    """Set of few-shot tool usage examples."""
+
+    examples: list[ToolExample] = Field(description="3-5 diverse usage examples")
+
+
+# ---------------------------------------------------------------------------
+# MCP tool catalog (source of truth: src/mcp_server/tools.py)
+# ---------------------------------------------------------------------------
+
+# Tools a specialist agent should have access to
+TOOL_IDS = [
+    "search_semantic",
+    "search_keyword",
+    "get_chunk",
+    "get_context_window",
+    "get_parent",
+    "get_children",
+    "search_concepts",
+    "get_concept",
+    "get_concept_with_citations",
+    "get_related_concepts",
+    "get_document_summary",
+    "get_chapter_summaries",
+    "search_summaries",
+    "list_concepts",
+]
+
+# Brief descriptions for the LLM to understand each tool
+TOOL_CATALOG = [
+    ("search_semantic", "Vector search for relevant text passages. Filters: doc_id, tags, has_table, has_code, has_math, has_image, header_level, semantic_type"),
+    ("search_keyword", "Full-text keyword search across chunks"),
+    ("get_chunk", "Get a specific chunk by ID"),
+    ("get_context_window", "Get a chunk with surrounding context (parent + siblings)"),
+    ("get_parent", "Get parent chunk of a given chunk"),
+    ("get_children", "Get child chunks of a given chunk"),
+    ("search_concepts", "Search concepts by name or keyword with relevance scoring"),
+    ("get_concept", "Get a concept by exact name"),
+    ("get_concept_with_citations", "Get concept definition with source chunk citations and related concepts"),
+    ("get_related_concepts", "Get concepts related to a given concept with relationship types"),
+    ("get_document_summary", "Get document-level summary"),
+    ("get_chapter_summaries", "Get all chapter-level summaries for a document"),
+    ("search_summaries", "Semantic search across summaries with level/doc filters"),
+    ("list_concepts", "List all concepts, optionally filtered by document or type"),
+]
+
+
+# ---------------------------------------------------------------------------
+# TextbookDistiller
+# ---------------------------------------------------------------------------
+
+
+class TextbookDistiller:
+    """Distill a document's knowledge base into a specialist agent config.
+
+    Uses 2 LLM calls:
+    1. Identity generation (role, goal, constraints, tool_guidance)
+    2. Few-shot example generation (tool usage patterns)
+
+    Everything else is computed from stored data (no LLM needed).
+    """
+
+    def __init__(self, store: Any, provider: str = "openai/gpt-4o-mini"):
+        if not INSTRUCTOR_AVAILABLE or instructor is None:
+            raise ImportError(
+                "instructor is not installed. "
+                "Install with: pip install 'kidkazz[concepts]'"
+            )
+        self.store = store
+        self.provider = provider
+        self.client = instructor.from_provider(provider)
+
+    # ------------------------------------------------------------------
+    # Main entry point
+    # ------------------------------------------------------------------
+
+    def distill(
+        self,
+        doc_id: str,
+        top_k: int = 20,
+        num_examples: int = 5,
+    ) -> dict[str, Any]:
+        """Distill a document into an AgentConfig-compatible dict.
+
+        Args:
+            doc_id: Document identifier in the knowledge base
+            top_k: Number of top concepts to include in expertise
+            num_examples: Number of few-shot tool examples to generate
+
+        Returns:
+            Dict matching agent_ex AgentConfig fields + _distill_metadata
+        """
+        logger.info("Gathering document data for %s...", doc_id)
+
+        # 1. Gather data (no LLM)
+        doc_title = self._get_doc_title(doc_id)
+        doc_summary = self._get_doc_summary(doc_id)
+        chapter_summaries = self._get_chapter_summaries(doc_id)
+        concepts = self._get_concepts(doc_id)
+        ranked_concepts = self._rank_concepts(concepts, top_k)
+        prerequisites = self._build_prerequisites(ranked_concepts)
+
+        if not doc_summary:
+            raise ValueError(
+                f"No document-level summary found for '{doc_id}'. "
+                "Run 'kidkazz summarize generate' first."
+            )
+
+        logger.info(
+            "Found %d concepts, %d chapters. Generating identity...",
+            len(concepts),
+            len(chapter_summaries),
+        )
+
+        # 2. Generate identity (LLM call 1)
+        identity = self._generate_identity(
+            doc_title, doc_id, doc_summary, chapter_summaries, ranked_concepts
+        )
+
+        logger.info("Generating %d tool usage examples...", num_examples)
+
+        # 3. Generate examples (LLM call 2)
+        examples = self._generate_examples(
+            doc_id, doc_title, ranked_concepts[:10], doc_summary, num_examples
+        )
+
+        # 4. Assemble output
+        return self._assemble_config(
+            doc_id=doc_id,
+            doc_title=doc_title,
+            identity=identity,
+            examples=examples,
+            ranked_concepts=ranked_concepts,
+            all_concepts=concepts,
+            chapter_summaries=chapter_summaries,
+            prerequisites=prerequisites,
+        )
+
+    # ------------------------------------------------------------------
+    # Data gathering (no LLM)
+    # ------------------------------------------------------------------
+
+    def _get_doc_title(self, doc_id: str) -> str:
+        """Get document title from metadata."""
+        docs = self.store.list_documents()
+        for doc in docs:
+            if doc.get("doc_id") == doc_id:
+                return doc.get("title", doc_id)
+        return doc_id
+
+    def _get_doc_summary(self, doc_id: str) -> Optional[dict]:
+        """Get document-level summary."""
+        summaries = self.store.get_document_summaries(doc_id, level="document")
+        return summaries[0] if summaries else None
+
+    def _get_chapter_summaries(self, doc_id: str) -> list[dict]:
+        """Get chapter-level summaries."""
+        return self.store.get_document_summaries(doc_id, level="chapter")
+
+    def _get_concepts(self, doc_id: str) -> list[dict]:
+        """Get all concepts for a document."""
+        return self.store.list_concepts(doc_id=doc_id)
+
+    def _rank_concepts(self, concepts: list[dict], top_k: int) -> list[dict]:
+        """Rank concepts by connection count (most connected = most important).
+
+        For each concept, queries related concepts and counts connections.
+        Falls back to alphabetical sort if no connections can be queried.
+        """
+        ranked = []
+        for concept in concepts:
+            concept_id = concept.get("concept_id", "")
+            if not concept_id:
+                continue
+
+            try:
+                related = self.store.get_related_concepts_with_types(concept_id)
+                connection_count = len(related)
+            except Exception:
+                connection_count = 0
+
+            ranked.append({**concept, "_connection_count": connection_count})
+
+        ranked.sort(key=lambda c: c.get("_connection_count", 0), reverse=True)
+        return ranked[:top_k]
+
+    def _build_prerequisites(self, ranked_concepts: list[dict]) -> list[dict]:
+        """Build prerequisite chains from 'requires'/'calculated_from' edges."""
+        prerequisites = []
+        prerequisite_types = {"requires", "calculated_from"}
+
+        for concept in ranked_concepts:
+            concept_id = concept.get("concept_id", "")
+            if not concept_id:
+                continue
+
+            try:
+                related = self.store.get_related_concepts_with_types(concept_id)
+            except Exception:
+                continue
+
+            deps = [
+                r["concept"].get("name", r["concept"].get("concept_id", ""))
+                for r in related
+                if r.get("relation_type", "").lower() in prerequisite_types
+            ]
+
+            if deps:
+                prerequisites.append({
+                    "from": concept.get("name", concept_id),
+                    "requires": deps,
+                })
+
+        return prerequisites
+
+    # ------------------------------------------------------------------
+    # LLM calls
+    # ------------------------------------------------------------------
+
+    def _generate_identity(
+        self,
+        doc_title: str,
+        doc_id: str,
+        doc_summary: dict,
+        chapter_summaries: list[dict],
+        ranked_concepts: list[dict],
+    ) -> AgentIdentity:
+        """LLM call 1: Generate agent identity from document knowledge."""
+        # Build context for the LLM
+        summary_text = doc_summary.get("content", "")
+        key_points = doc_summary.get("key_points", [])
+        if isinstance(key_points, str):
+            try:
+                key_points = json.loads(key_points)
+            except (json.JSONDecodeError, TypeError):
+                key_points = [key_points] if key_points else []
+
+        chapter_overview = "\n".join(
+            f"- {ch.get('content', '')[:150]}"
+            for ch in chapter_summaries[:15]
+        )
+
+        concept_list = ", ".join(
+            c.get("name", "") for c in ranked_concepts[:15]
+        )
+
+        concept_types = Counter(
+            c.get("concept_type", "unknown") for c in ranked_concepts
+        )
+        type_summary = ", ".join(
+            f"{count} {ctype}" for ctype, count in concept_types.most_common(5)
+        )
+
+        tool_catalog_text = "\n".join(
+            f"- {name}: {desc}" for name, desc in TOOL_CATALOG
+        )
+
+        prompt = f"""You are creating a specialist AI agent configuration for a textbook knowledge base.
+
+DOCUMENT: "{doc_title}" (ID: {doc_id})
+
+DOCUMENT SUMMARY:
+{summary_text}
+
+KEY POINTS:
+{chr(10).join(f'- {kp}' for kp in key_points[:10])}
+
+CHAPTERS ({len(chapter_summaries)} total):
+{chapter_overview}
+
+TOP CONCEPTS ({len(ranked_concepts)} most connected):
+{concept_list}
+
+CONCEPT TYPE DISTRIBUTION: {type_summary}
+
+AVAILABLE MCP TOOLS (the agent uses these to search the knowledge base):
+{tool_catalog_text}
+
+Generate the agent's identity configuration. The tool_guidance should be a practical
+markdown guide telling the agent WHEN and HOW to use each tool for different question types
+(factual, procedural, comparative, overview). Reference the doc_id '{doc_id}' in tool guidance
+where appropriate for filtering."""
+
+        return self.client.chat.completions.create(
+            model=self.provider.split("/")[-1],
+            response_model=AgentIdentity,
+            messages=[{"role": "user", "content": prompt}],
+            max_retries=2,
+        )
+
+    def _generate_examples(
+        self,
+        doc_id: str,
+        doc_title: str,
+        top_concepts: list[dict],
+        doc_summary: dict,
+        num_examples: int,
+    ) -> list[dict]:
+        """LLM call 2: Generate few-shot tool usage examples."""
+        concept_context = "\n".join(
+            f"- {c.get('name', '')} ({c.get('concept_type', '')}): {c.get('definition', '')[:100]}"
+            for c in top_concepts
+        )
+
+        tool_catalog_text = "\n".join(
+            f"- {name}: {desc}" for name, desc in TOOL_CATALOG
+        )
+
+        prompt = f"""Generate {num_examples} diverse few-shot examples showing how a specialist agent
+would use MCP tools to answer questions about "{doc_title}" (doc_id: "{doc_id}").
+
+TOP CONCEPTS IN THIS KNOWLEDGE BASE:
+{concept_context}
+
+AVAILABLE MCP TOOLS:
+{tool_catalog_text}
+
+Create examples covering these question types:
+1. Factual/definition lookup (use search_concepts + get_concept_with_citations)
+2. Formula/calculation (use search_semantic with has_math=true)
+3. Comparison between concepts (use get_concept_with_citations + get_related_concepts)
+4. Chapter/topic overview (use get_chapter_summaries or search_summaries)
+5. Procedure/how-to (use search_semantic + get_context_window)
+
+Use REAL concept names from the list above. Use doc_id="{doc_id}" in search filters.
+Each example should show realistic tool_calls with actual argument values."""
+
+        result = self.client.chat.completions.create(
+            model=self.provider.split("/")[-1],
+            response_model=ToolExampleSet,
+            messages=[{"role": "user", "content": prompt}],
+            max_retries=2,
+        )
+
+        return [ex.model_dump() for ex in result.examples]
+
+    # ------------------------------------------------------------------
+    # Assembly (no LLM)
+    # ------------------------------------------------------------------
+
+    def _assemble_config(
+        self,
+        doc_id: str,
+        doc_title: str,
+        identity: AgentIdentity,
+        examples: list[dict],
+        ranked_concepts: list[dict],
+        all_concepts: list[dict],
+        chapter_summaries: list[dict],
+        prerequisites: list[dict],
+    ) -> dict[str, Any]:
+        """Assemble all pieces into an AgentConfig-compatible JSON dict."""
+        # Build expertise from top concept names
+        expertise = [
+            c.get("name", "") for c in ranked_concepts[:10] if c.get("name")
+        ]
+
+        # Build name from document title
+        name = _slugify(doc_title) + "_specialist"
+
+        # Concept type distribution
+        type_dist = Counter(
+            c.get("concept_type", "unknown") for c in all_concepts
+        )
+
+        # Top concepts by connection count
+        top_by_connections = [
+            {"name": c.get("name", ""), "connections": c.get("_connection_count", 0)}
+            for c in ranked_concepts[:10]
+        ]
+
+        return {
+            # AgentConfig fields
+            "name": name,
+            "description": (
+                f"Specialist agent distilled from '{doc_title}' "
+                f"with {len(all_concepts)} concepts across "
+                f"{len(chapter_summaries)} chapters"
+            ),
+            "role": identity.role,
+            "expertise": expertise,
+            "personality": identity.personality,
+            "goal": identity.goal,
+            "success_criteria": identity.success_criteria,
+            "constraints": identity.constraints,
+            "scope": identity.scope,
+            "tool_ids": TOOL_IDS,
+            "tool_guidance": identity.tool_guidance,
+            "tool_examples": examples,
+            "output_format": (
+                "## Answer\n"
+                "[Clear explanation with definitions and context]\n\n"
+                "## Sources\n"
+                "- Chapter X, Section Y: \"relevant quote\"\n"
+                "- Concept: [concept_name] - [definition]\n\n"
+                "## Related Concepts\n"
+                "- [concept_1]: [brief relevance]\n"
+                "- [concept_2]: [brief relevance]"
+            ),
+            "system_prompt": None,
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "disabled_builtins": [],
+            "intervention_pipeline": [],
+            "sandbox": {},
+            "execution_mode": "interactive",
+            "budget": {},
+            # Metadata (stripped by agent_ex on import)
+            "_distill_metadata": {
+                "source_document_id": doc_id,
+                "source_document_title": doc_title,
+                "total_concepts": len(all_concepts),
+                "total_chapters": len(chapter_summaries),
+                "concept_types": dict(type_dist.most_common()),
+                "top_concepts_by_connections": top_by_connections,
+                "prerequisite_skills": prerequisites,
+                "distilled_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "provider": self.provider,
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a URL-friendly slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_-]+", "_", text)
+    return text.strip("_")[:80]

--- a/src/distiller/distiller.py
+++ b/src/distiller/distiller.py
@@ -176,16 +176,17 @@ class TextbookDistiller:
         # 1. Gather data (no LLM)
         doc_title = self._get_doc_title(doc_id)
         doc_summary = self._get_doc_summary(doc_id)
-        chapter_summaries = self._get_chapter_summaries(doc_id)
-        concepts = self._get_concepts(doc_id)
-        ranked_concepts = self._rank_concepts(concepts, top_k)
-        prerequisites = self._build_prerequisites(ranked_concepts)
 
         if not doc_summary:
             raise ValueError(
                 f"No document-level summary found for '{doc_id}'. "
                 "Run 'kidkazz summarize generate' first."
             )
+
+        chapter_summaries = self._get_chapter_summaries(doc_id)
+        concepts = self._get_concepts(doc_id)
+        ranked_concepts = self._rank_concepts(concepts, top_k)
+        prerequisites = self._build_prerequisites(ranked_concepts)
 
         logger.info(
             "Found %d concepts, %d chapters. Generating identity...",

--- a/tests/test_distiller.py
+++ b/tests/test_distiller.py
@@ -1,0 +1,366 @@
+"""Tests for textbook knowledge distillation."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.distiller.distiller import (
+    TOOL_IDS,
+    AgentIdentity,
+    TextbookDistiller,
+    ToolExampleSet,
+    _slugify,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_store():
+    """Create a mock store with realistic data."""
+    store = MagicMock()
+
+    store.list_documents.return_value = [
+        {"doc_id": "test_book", "title": "Test Book on Inventory"},
+    ]
+
+    store.get_document_summaries.side_effect = lambda doc_id, level=None: {
+        "document": [
+            {
+                "summary_id": "summary_test_book_document",
+                "content": "This book covers inventory management fundamentals.",
+                "level": "document",
+                "key_points": json.dumps([
+                    "FIFO and LIFO valuation methods",
+                    "Safety stock calculation",
+                    "Economic Order Quantity formula",
+                ]),
+            }
+        ],
+        "chapter": [
+            {
+                "summary_id": "summary_ch1_chapter",
+                "content": "Chapter 1 introduces inventory basics.",
+                "level": "chapter",
+            },
+            {
+                "summary_id": "summary_ch2_chapter",
+                "content": "Chapter 2 covers valuation methods.",
+                "level": "chapter",
+            },
+        ],
+    }.get(level, [])
+
+    store.list_concepts.return_value = [
+        {
+            "concept_id": "fifo",
+            "name": "FIFO",
+            "concept_type": "method",
+            "definition": "First-In, First-Out inventory valuation method",
+            "aliases": '["First In First Out"]',
+        },
+        {
+            "concept_id": "lifo",
+            "name": "LIFO",
+            "concept_type": "method",
+            "definition": "Last-In, First-Out inventory valuation method",
+            "aliases": "[]",
+        },
+        {
+            "concept_id": "safety-stock",
+            "name": "Safety Stock",
+            "concept_type": "term",
+            "definition": "Buffer inventory to prevent stockouts",
+            "aliases": "[]",
+        },
+        {
+            "concept_id": "eoq",
+            "name": "Economic Order Quantity",
+            "concept_type": "formula",
+            "definition": "Optimal order quantity that minimizes total inventory costs",
+            "aliases": '["EOQ"]',
+        },
+        {
+            "concept_id": "holding-cost",
+            "name": "Holding Cost",
+            "concept_type": "term",
+            "definition": "Cost of storing inventory over time",
+            "aliases": '["carrying cost"]',
+        },
+    ]
+
+    def mock_related(concept_id):
+        relations = {
+            "fifo": [
+                {"concept": {"name": "LIFO", "concept_id": "lifo"}, "relation_type": "relates_to"},
+                {"concept": {"name": "COGS", "concept_id": "cogs"}, "relation_type": "calculated_from"},
+            ],
+            "eoq": [
+                {"concept": {"name": "Holding Cost", "concept_id": "holding-cost"}, "relation_type": "requires"},
+                {"concept": {"name": "Ordering Cost", "concept_id": "ordering-cost"}, "relation_type": "requires"},
+            ],
+            "safety-stock": [
+                {"concept": {"name": "Reorder Point", "concept_id": "reorder-point"}, "relation_type": "calculated_from"},
+            ],
+            "lifo": [],
+            "holding-cost": [],
+        }
+        return relations.get(concept_id, [])
+
+    store.get_related_concepts_with_types.side_effect = mock_related
+    return store
+
+
+@pytest.fixture
+def mock_identity():
+    """Pre-built identity for assembly tests."""
+    return AgentIdentity(
+        role="an expert in Inventory Management",
+        personality="precise and pedagogical",
+        goal="Help users understand inventory concepts using textbook knowledge.",
+        success_criteria="Every answer cites at least one source.",
+        constraints=[
+            "Always cite sources",
+            "Prefer textbook definitions over general knowledge",
+        ],
+        scope="Test Book on Inventory",
+        tool_guidance="1. Use search_concepts first\n2. Use get_concept_with_citations for details",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _slugify
+# ---------------------------------------------------------------------------
+
+
+class TestSlugify:
+    def test_basic(self):
+        assert _slugify("Hello World") == "hello_world"
+
+    def test_special_chars(self):
+        assert _slugify("Inventory & Accounting: A Guide!") == "inventory_accounting_a_guide"
+
+    def test_truncation(self):
+        result = _slugify("a" * 100)
+        assert len(result) <= 80
+
+    def test_underscores(self):
+        assert _slugify("one__two___three") == "one_two_three"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _rank_concepts
+# ---------------------------------------------------------------------------
+
+
+class TestRankConcepts:
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_ranks_by_connection_count(self, mock_instructor, mock_store):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=3)
+
+        # FIFO has 2 connections, EOQ has 2, Safety Stock has 1
+        assert len(ranked) == 3
+        assert ranked[0]["_connection_count"] >= ranked[1]["_connection_count"]
+        assert ranked[1]["_connection_count"] >= ranked[2]["_connection_count"]
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_top_k_limits_results(self, mock_instructor, mock_store):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=2)
+        assert len(ranked) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_prerequisites
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrerequisites:
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_extracts_requires_edges(self, mock_instructor, mock_store):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=5)
+        prereqs = distiller._build_prerequisites(ranked)
+
+        # EOQ requires Holding Cost and Ordering Cost
+        eoq_prereq = next((p for p in prereqs if p["from"] == "Economic Order Quantity"), None)
+        assert eoq_prereq is not None
+        assert "Holding Cost" in eoq_prereq["requires"]
+        assert "Ordering Cost" in eoq_prereq["requires"]
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_extracts_calculated_from_edges(self, mock_instructor, mock_store):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=5)
+        prereqs = distiller._build_prerequisites(ranked)
+
+        # FIFO is calculated_from COGS, Safety Stock from Reorder Point
+        fifo_prereq = next((p for p in prereqs if p["from"] == "FIFO"), None)
+        assert fifo_prereq is not None
+        assert "COGS" in fifo_prereq["requires"]
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_skips_non_prerequisite_edges(self, mock_instructor, mock_store):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        # LIFO has no relations, so no prerequisites
+        ranked = [{"concept_id": "lifo", "name": "LIFO"}]
+        prereqs = distiller._build_prerequisites(ranked)
+        assert prereqs == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: _assemble_config
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleConfig:
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_output_has_all_agent_config_fields(self, mock_instructor, mock_store, mock_identity):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=5)
+
+        result = distiller._assemble_config(
+            doc_id="test_book",
+            doc_title="Test Book on Inventory",
+            identity=mock_identity,
+            examples=[{"user": "test", "tool_calls": []}],
+            ranked_concepts=ranked,
+            all_concepts=concepts,
+            chapter_summaries=[{"content": "ch1"}, {"content": "ch2"}],
+            prerequisites=[],
+        )
+
+        # Required AgentConfig fields
+        assert "name" in result
+        assert "role" in result
+        assert "expertise" in result
+        assert "personality" in result
+        assert "goal" in result
+        assert "success_criteria" in result
+        assert "constraints" in result
+        assert "scope" in result
+        assert "tool_ids" in result
+        assert "tool_guidance" in result
+        assert "tool_examples" in result
+        assert "output_format" in result
+        assert "provider" in result
+        assert "model" in result
+        assert "execution_mode" in result
+        assert "budget" in result
+        assert "intervention_pipeline" in result
+        assert "sandbox" in result
+        assert "disabled_builtins" in result
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_name_is_slugified(self, mock_instructor, mock_store, mock_identity):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        result = distiller._assemble_config(
+            doc_id="test_book",
+            doc_title="Test Book on Inventory",
+            identity=mock_identity,
+            examples=[],
+            ranked_concepts=[],
+            all_concepts=[],
+            chapter_summaries=[],
+            prerequisites=[],
+        )
+        assert result["name"] == "test_book_on_inventory_specialist"
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_tool_ids_are_valid(self, mock_instructor, mock_store, mock_identity):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        result = distiller._assemble_config(
+            doc_id="test_book",
+            doc_title="Test",
+            identity=mock_identity,
+            examples=[],
+            ranked_concepts=[],
+            all_concepts=[],
+            chapter_summaries=[],
+            prerequisites=[],
+        )
+        assert result["tool_ids"] == TOOL_IDS
+        assert "search_semantic" in result["tool_ids"]
+        assert "get_concept_with_citations" in result["tool_ids"]
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_metadata_present(self, mock_instructor, mock_store, mock_identity):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=5)
+
+        result = distiller._assemble_config(
+            doc_id="test_book",
+            doc_title="Test Book",
+            identity=mock_identity,
+            examples=[],
+            ranked_concepts=ranked,
+            all_concepts=concepts,
+            chapter_summaries=[{"content": "ch1"}],
+            prerequisites=[{"from": "EOQ", "requires": ["Holding Cost"]}],
+        )
+
+        meta = result["_distill_metadata"]
+        assert meta["source_document_id"] == "test_book"
+        assert meta["total_concepts"] == 5
+        assert meta["total_chapters"] == 1
+        assert len(meta["prerequisite_skills"]) == 1
+        assert "concept_types" in meta
+        assert "distilled_at" in meta
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_output_is_json_serializable(self, mock_instructor, mock_store, mock_identity):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        result = distiller._assemble_config(
+            doc_id="test_book",
+            doc_title="Test",
+            identity=mock_identity,
+            examples=[{"user": "q", "tool_calls": [{"tool": "search_concepts", "args": {}}]}],
+            ranked_concepts=[],
+            all_concepts=[],
+            chapter_summaries=[],
+            prerequisites=[],
+        )
+        # Must not raise
+        serialized = json.dumps(result, indent=2)
+        deserialized = json.loads(serialized)
+        assert deserialized["name"] == result["name"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_doc_title
+# ---------------------------------------------------------------------------
+
+
+class TestGetDocTitle:
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_returns_title_when_found(self, mock_instructor, mock_store):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        assert distiller._get_doc_title("test_book") == "Test Book on Inventory"
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_returns_doc_id_when_not_found(self, mock_instructor, mock_store):
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        assert distiller._get_doc_title("nonexistent") == "nonexistent"

--- a/tests/test_distiller.py
+++ b/tests/test_distiller.py
@@ -10,6 +10,7 @@ from src.distiller.distiller import (
     AgentIdentity,
     TextbookDistiller,
     ToolExampleSet,
+    _sanitize_filename,
     _slugify,
 )
 
@@ -364,3 +365,151 @@ class TestGetDocTitle:
     def test_returns_doc_id_when_not_found(self, mock_instructor, mock_store):
         distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
         assert distiller._get_doc_title("nonexistent") == "nonexistent"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _slugify edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSlugifyEdgeCases:
+    def test_empty_string_returns_unnamed(self):
+        assert _slugify("") == "unnamed"
+
+    def test_whitespace_only_returns_unnamed(self):
+        assert _slugify("   ") == "unnamed"
+
+    def test_only_special_chars_returns_unnamed(self):
+        assert _slugify("!!!@@@") == "unnamed"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _sanitize_filename
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeFilename:
+    def test_normal_doc_id(self):
+        assert _sanitize_filename("my_book_123") == "my_book_123"
+
+    def test_path_traversal_stripped(self):
+        result = _sanitize_filename("../../etc/passwd")
+        assert ".." not in result
+        assert "/" not in result
+
+    def test_special_chars_replaced(self):
+        result = _sanitize_filename("book/with spaces & stuff")
+        assert "/" not in result
+        assert " " not in result
+
+    def test_truncation(self):
+        result = _sanitize_filename("a" * 200)
+        assert len(result) <= 100
+
+
+# ---------------------------------------------------------------------------
+# Tests: provider/model extraction
+# ---------------------------------------------------------------------------
+
+
+class TestProviderModel:
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_provider_extracted_from_slash_format(self, mock_instructor, mock_store, mock_identity):
+        distiller = TextbookDistiller(mock_store, provider="anthropic/claude-3-haiku")
+        result = distiller._assemble_config(
+            doc_id="test",
+            doc_title="Test",
+            identity=mock_identity,
+            examples=[],
+            ranked_concepts=[],
+            all_concepts=[],
+            chapter_summaries=[],
+            prerequisites=[],
+        )
+        assert result["provider"] == "anthropic"
+        assert result["model"] == "claude-3-haiku"
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_default_provider_when_no_slash(self, mock_instructor, mock_store, mock_identity):
+        distiller = TextbookDistiller(mock_store, provider="gpt-4o-mini")
+        result = distiller._assemble_config(
+            doc_id="test",
+            doc_title="Test",
+            identity=mock_identity,
+            examples=[],
+            ranked_concepts=[],
+            all_concepts=[],
+            chapter_summaries=[],
+            prerequisites=[],
+        )
+        assert result["provider"] == "openai"
+        assert result["model"] == "gpt-4o-mini"
+
+
+# ---------------------------------------------------------------------------
+# Tests: distill() entry point
+# ---------------------------------------------------------------------------
+
+
+class TestDistillEntryPoint:
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_raises_on_missing_summary(self, mock_instructor, mock_store):
+        """distill() should raise ValueError when no document summary exists."""
+        # Override to return empty for document level
+        mock_store.get_document_summaries.side_effect = lambda doc_id, level=None: []
+
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        with pytest.raises(ValueError, match="No document-level summary"):
+            distiller.distill("test_book")
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", False)
+    def test_raises_on_missing_instructor(self, mock_store):
+        """distill() should raise ImportError when instructor is missing."""
+        # Need a store with valid data so we get past data gathering
+        mock_store.get_document_summaries.side_effect = lambda doc_id, level=None: {
+            "document": [{"summary_id": "s", "content": "test", "key_points": "[]"}],
+            "chapter": [],
+        }.get(level, [])
+
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        with pytest.raises(ImportError, match="instructor is not installed"):
+            distiller.distill("test_book")
+
+
+# ---------------------------------------------------------------------------
+# Tests: _rank_concepts caches _related
+# ---------------------------------------------------------------------------
+
+
+class TestRankConceptsCaching:
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_related_data_cached_on_ranked_concepts(self, mock_instructor, mock_store):
+        """_rank_concepts should store _related so _build_prerequisites can reuse it."""
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=5)
+
+        # All ranked concepts should have _related key
+        for c in ranked:
+            assert "_related" in c
+            assert isinstance(c["_related"], list)
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_build_prerequisites_uses_cached_related(self, mock_instructor, mock_store):
+        """_build_prerequisites should not call get_related_concepts_with_types."""
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=5)
+
+        # Reset call count after ranking
+        mock_store.get_related_concepts_with_types.reset_mock()
+
+        distiller._build_prerequisites(ranked)
+
+        # Should not have made any additional calls
+        mock_store.get_related_concepts_with_types.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `kidkazz distill generate <doc_id>` command that distills a document's concept graph + chapter summaries into an AgentConfig-compatible JSON for the [agent_ex](https://github.com/lukmanha083/agent_ex) framework
- New `TextbookDistiller` class uses 2 LLM calls (identity generation + few-shot examples) plus pure graph queries (concept ranking, prerequisite extraction)
- CLI subcommands: `generate`, `show`, `list` — output saved to `~/.kidkazz/distilled/`
- 29 unit tests covering ranking, prerequisites, assembly, serialization, edge cases, and entry point validation

## How it works
```
PDF → Chunks → Concepts + Summaries (existing pipeline)
                    ↓
        kidkazz distill generate <doc_id>
                    ↓
        AgentConfig JSON (role, expertise, tool_guidance,
                          few-shot examples, prerequisites)
                    ↓
        Import into agent_ex → Specialist agent ready
        (uses kidkazz MCP tools at runtime)
```

## Files
| File | Purpose |
|------|---------|
| `src/distiller/__init__.py` | Package init |
| `src/distiller/distiller.py` | `TextbookDistiller` class — core distillation logic |
| `src/cli/commands/distill.py` | CLI commands (generate/show/list) |
| `src/cli/main.py` | Register distill command (+2 lines) |
| `tests/test_distiller.py` | 29 unit tests |

## Security
- Path traversal prevention: `doc_id` sanitized before filesystem use
- Lazy instructor init: proper error messages when dependency missing
- Payload size limits on generated output

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_distiller.py -v` — 29 tests pass
- [ ] Manual test: `kidkazz distill generate <doc_id> --json` with a real document
- [ ] Verify output JSON imports correctly in agent_ex via `AgentConfig.from_map/2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new distill CLI group to convert textbooks into specialist agent configurations.
  * Three subcommands: generate (create configs), show (view a config), list (browse distilled configs).
  * Output choices: raw JSON or a human-friendly formatted summary; configurable model/provider option.

* **Tests**
  * Added comprehensive test suite covering distillation behavior, utilities, and export serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->