### PR TITLE
perf: fix N+1 query in _rank_concepts with two-phase concurrent ranking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ helixdb-cfg/
 
 # Local configuration
 .kidkazz.toml
+
+# Generated graph/visualization outputs
+concept_graph.html
+*.dot
+graph.svg
+graph.png

--- a/src/cli/commands/db.py
+++ b/src/cli/commands/db.py
@@ -1052,9 +1052,8 @@ def _get_local_data_dir() -> Path:
     return data_dir
 
 
-def _get_data_size(path: Path) -> str:
-    """Return human-readable total size of a directory."""
-    total = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+def _format_size(total: int) -> str:
+    """Format byte count as human-readable string."""
     if total >= 1024 * 1024 * 1024:
         return f"{total / (1024 ** 3):.1f} GB"
     if total >= 1024 * 1024:
@@ -1062,6 +1061,15 @@ def _get_data_size(path: Path) -> str:
     if total >= 1024:
         return f"{total / 1024:.1f} KB"
     return f"{total} B"
+
+
+def _get_data_size(path: Path) -> str:
+    """Return human-readable total size of a directory or file."""
+    if path.is_file():
+        total = path.stat().st_size
+    else:
+        total = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+    return _format_size(total)
 
 
 @app.command("sync")
@@ -1197,7 +1205,7 @@ def sync_to_fly(
         with tarfile.open(tarball_path, "w:gz") as tar:
             # Add user/ directory (arcname ensures it extracts as user/)
             tar.add(str(data_dir), arcname="user")
-        tarball_size = _get_data_size(tarball_path.parent / tarball_path.name)
+        tarball_size = _get_data_size(tarball_path)
         if not json_output:
             print_info(f"Tarball created: {tarball_size} (compressed)")
 

--- a/src/distiller/distiller.py
+++ b/src/distiller/distiller.py
@@ -268,6 +268,8 @@ class TextbookDistiller:
                 return (concept, 0)
             try:
                 count = self.store.count_concept_edges_direct(internal_id)
+            except (AttributeError, TypeError):
+                raise  # Contract violation — store missing required method
             except Exception as e:
                 logger.warning(
                     "Failed to count edges for %s: %s",
@@ -296,6 +298,8 @@ class TextbookDistiller:
                 continue
             try:
                 related = self.store.get_related_concepts_with_types_direct(internal_id)
+            except (AttributeError, TypeError):
+                raise  # Contract violation — store missing required method
             except Exception as e:
                 logger.warning(
                     "Failed to get related concepts for %s: %s",

--- a/src/distiller/distiller.py
+++ b/src/distiller/distiller.py
@@ -12,6 +12,7 @@ import logging
 import re
 import time
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
@@ -113,6 +114,8 @@ TOOL_CATALOG = [
     ("search_summaries", "Semantic search across summaries with level/doc filters"),
     ("list_concepts", "List all concepts, optionally filtered by document or type"),
 ]
+
+TOOL_CATALOG_TEXT = "\n".join(f"- {name}: {desc}" for name, desc in TOOL_CATALOG)
 
 
 # ---------------------------------------------------------------------------
@@ -248,35 +251,64 @@ class TextbookDistiller:
     def _rank_concepts(self, concepts: list[dict], top_k: int) -> list[dict]:
         """Rank concepts by connection count (most connected = most important).
 
-        For each concept, queries related concepts and counts connections.
-        Caches the related data in ``_related`` so ``_build_prerequisites``
-        can reuse it without re-querying.
+        Two-phase approach to avoid fetching full relationship data for all
+        ~2000 concepts when only top_k (default 20) are kept:
+
+        Phase 1: Count edges concurrently for all concepts using internal
+        Helix IDs (skips per-concept get_concept() lookup). Uses
+        ThreadPoolExecutor for ~10x wall-clock speedup.
+
+        Phase 2: Fetch full relationship data only for top_k concepts.
+        Caches in ``_related`` so ``_build_prerequisites`` can reuse it.
         """
-        ranked = []
-        skipped = 0
-        for concept in concepts:
-            concept_id = concept.get("concept_id", "")
-            if not concept_id:
-                skipped += 1
-                continue
-
+        # Phase 1: Count edges concurrently for all concepts
+        def _count_edges(concept: dict) -> tuple[dict, int]:
+            internal_id = concept.get("id")
+            if not internal_id:
+                return (concept, 0)
             try:
-                related = self.store.get_related_concepts_with_types(concept_id)
+                count = self.store.count_concept_edges_direct(internal_id)
             except Exception as e:
-                logger.warning("Failed to get related concepts for %s: %s", concept_id, e)
-                related = []
+                logger.warning(
+                    "Failed to count edges for %s: %s",
+                    concept.get("concept_id", "?"), e,
+                )
+                count = 0
+            return (concept, count)
 
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            counted = list(pool.map(_count_edges, concepts))
+
+        counted.sort(key=lambda x: x[1], reverse=True)
+        top = counted[:top_k]
+
+        logger.info(
+            "Phase 1 complete: counted edges for %d concepts, top %d selected",
+            len(counted), len(top),
+        )
+
+        # Phase 2: Fetch full _related data ONLY for top_k
+        ranked = []
+        for concept, count in top:
+            internal_id = concept.get("id")
+            if not internal_id:
+                ranked.append({**concept, "_connection_count": count, "_related": []})
+                continue
+            try:
+                related = self.store.get_related_concepts_with_types_direct(internal_id)
+            except Exception as e:
+                logger.warning(
+                    "Failed to get related concepts for %s: %s",
+                    concept.get("concept_id", "?"), e,
+                )
+                related = []
             ranked.append({
                 **concept,
-                "_connection_count": len(related),
+                "_connection_count": count,
                 "_related": related,
             })
 
-        if skipped:
-            logger.warning("Skipped %d concepts with missing concept_id", skipped)
-
-        ranked.sort(key=lambda c: c.get("_connection_count", 0), reverse=True)
-        return ranked[:top_k]
+        return ranked
 
     def _build_prerequisites(self, ranked_concepts: list[dict]) -> list[dict]:
         """Build prerequisite chains from 'requires'/'calculated_from' edges.
@@ -346,10 +378,6 @@ class TextbookDistiller:
             f"{count} {ctype}" for ctype, count in concept_types.most_common(5)
         )
 
-        tool_catalog_text = "\n".join(
-            f"- {name}: {desc}" for name, desc in TOOL_CATALOG
-        )
-
         prompt = f"""You are creating a specialist AI agent configuration for a textbook knowledge base.
 
 DOCUMENT: "{doc_title}" (ID: {doc_id})
@@ -369,7 +397,7 @@ TOP CONCEPTS ({len(ranked_concepts)} most connected):
 CONCEPT TYPE DISTRIBUTION: {type_summary}
 
 AVAILABLE MCP TOOLS (the agent uses these to search the knowledge base):
-{tool_catalog_text}
+{TOOL_CATALOG_TEXT}
 
 Generate the agent's identity configuration. The tool_guidance should be a practical
 markdown guide telling the agent WHEN and HOW to use each tool for different question types
@@ -397,10 +425,6 @@ where appropriate for filtering."""
             for c in top_concepts
         )
 
-        tool_catalog_text = "\n".join(
-            f"- {name}: {desc}" for name, desc in TOOL_CATALOG
-        )
-
         prompt = f"""Generate {num_examples} diverse few-shot examples showing how a specialist agent
 would use MCP tools to answer questions about "{doc_title}" (doc_id: "{doc_id}").
 
@@ -408,7 +432,7 @@ TOP CONCEPTS IN THIS KNOWLEDGE BASE:
 {concept_context}
 
 AVAILABLE MCP TOOLS:
-{tool_catalog_text}
+{TOOL_CATALOG_TEXT}
 
 Create examples covering these question types:
 1. Factual/definition lookup (use search_concepts + get_concept_with_citations)
@@ -527,8 +551,3 @@ def _slugify(text: str) -> str:
     text = re.sub(r"[\s_-]+", "_", text)
     result = text.strip("_")[:80]
     return result or "unnamed"
-
-
-def _sanitize_filename(doc_id: str) -> str:
-    """Sanitize a doc_id for use in a filename (prevent path traversal)."""
-    return re.sub(r"[^\w\-]", "_", doc_id)[:100]

--- a/src/storage/client.py
+++ b/src/storage/client.py
@@ -1664,6 +1664,52 @@ class HelixChunkStore:
 
         return results
 
+    def count_concept_edges_direct(self, internal_id: str) -> int:
+        """Count outgoing typed edges for a concept using its internal Helix ID.
+
+        Queries all typed edge types (Uses, Requires, etc.) and returns the
+        total count. Skips the get_concept() lookup since the caller already
+        has the internal node ID (e.g. from list_concepts()).
+
+        Args:
+            internal_id: Internal Helix node ID
+
+        Returns:
+            Total number of outgoing typed edges
+        """
+        self._ensure_connected()
+        count = 0
+        for query_class in TYPED_CONCEPT_QUERIES_FORWARD.values():
+            result = self._execute_query(query_class(internal_id))
+            if result.success and result.data:
+                count += len(result.data)
+        return count
+
+    def get_related_concepts_with_types_direct(self, internal_id: str) -> list[dict]:
+        """Get related concepts with types using internal Helix ID directly.
+
+        Same as get_related_concepts_with_types() but skips the get_concept()
+        lookup. Use when the internal node ID is already known (e.g. from
+        list_concepts()).
+
+        Args:
+            internal_id: Internal Helix node ID
+
+        Returns:
+            List of dicts with 'concept' (target concept data) and 'relation_type'
+        """
+        self._ensure_connected()
+        results = []
+        for relation_type, query_class in TYPED_CONCEPT_QUERIES_FORWARD.items():
+            result = self._execute_query(query_class(internal_id))
+            if result.success and result.data:
+                for target_concept in result.data:
+                    results.append({
+                        "concept": target_concept,
+                        "relation_type": relation_type,
+                    })
+        return results
+
     def get_concept_dependents(self, concept_id: str) -> list[dict]:
         """
         Get concepts that relate TO this concept (reverse relationships).

--- a/tests/test_distiller.py
+++ b/tests/test_distiller.py
@@ -5,12 +5,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.cli.commands.distill import _safe_filename
 from src.distiller.distiller import (
     TOOL_IDS,
     AgentIdentity,
     TextbookDistiller,
     ToolExampleSet,
-    _sanitize_filename,
     _slugify,
 )
 
@@ -58,6 +58,7 @@ def mock_store():
 
     store.list_concepts.return_value = [
         {
+            "id": "helix_fifo",
             "concept_id": "fifo",
             "name": "FIFO",
             "concept_type": "method",
@@ -65,6 +66,7 @@ def mock_store():
             "aliases": '["First In First Out"]',
         },
         {
+            "id": "helix_lifo",
             "concept_id": "lifo",
             "name": "LIFO",
             "concept_type": "method",
@@ -72,6 +74,7 @@ def mock_store():
             "aliases": "[]",
         },
         {
+            "id": "helix_safety_stock",
             "concept_id": "safety-stock",
             "name": "Safety Stock",
             "concept_type": "term",
@@ -79,6 +82,7 @@ def mock_store():
             "aliases": "[]",
         },
         {
+            "id": "helix_eoq",
             "concept_id": "eoq",
             "name": "Economic Order Quantity",
             "concept_type": "formula",
@@ -86,6 +90,7 @@ def mock_store():
             "aliases": '["EOQ"]',
         },
         {
+            "id": "helix_holding_cost",
             "concept_id": "holding-cost",
             "name": "Holding Cost",
             "concept_type": "term",
@@ -94,25 +99,44 @@ def mock_store():
         },
     ]
 
+    # Related data keyed by internal Helix ID (used by _direct methods)
+    _related_by_internal_id = {
+        "helix_fifo": [
+            {"concept": {"name": "LIFO", "concept_id": "lifo"}, "relation_type": "relates_to"},
+            {"concept": {"name": "COGS", "concept_id": "cogs"}, "relation_type": "calculated_from"},
+        ],
+        "helix_eoq": [
+            {"concept": {"name": "Holding Cost", "concept_id": "holding-cost"}, "relation_type": "requires"},
+            {"concept": {"name": "Ordering Cost", "concept_id": "ordering-cost"}, "relation_type": "requires"},
+        ],
+        "helix_safety_stock": [
+            {"concept": {"name": "Reorder Point", "concept_id": "reorder-point"}, "relation_type": "calculated_from"},
+        ],
+        "helix_lifo": [],
+        "helix_holding_cost": [],
+    }
+
+    # Legacy method (keyed by concept_id string)
     def mock_related(concept_id):
         relations = {
-            "fifo": [
-                {"concept": {"name": "LIFO", "concept_id": "lifo"}, "relation_type": "relates_to"},
-                {"concept": {"name": "COGS", "concept_id": "cogs"}, "relation_type": "calculated_from"},
-            ],
-            "eoq": [
-                {"concept": {"name": "Holding Cost", "concept_id": "holding-cost"}, "relation_type": "requires"},
-                {"concept": {"name": "Ordering Cost", "concept_id": "ordering-cost"}, "relation_type": "requires"},
-            ],
-            "safety-stock": [
-                {"concept": {"name": "Reorder Point", "concept_id": "reorder-point"}, "relation_type": "calculated_from"},
-            ],
+            "fifo": _related_by_internal_id["helix_fifo"],
+            "eoq": _related_by_internal_id["helix_eoq"],
+            "safety-stock": _related_by_internal_id["helix_safety_stock"],
             "lifo": [],
             "holding-cost": [],
         }
         return relations.get(concept_id, [])
 
     store.get_related_concepts_with_types.side_effect = mock_related
+
+    # New direct methods (keyed by internal Helix ID)
+    store.count_concept_edges_direct.side_effect = lambda iid: len(
+        _related_by_internal_id.get(iid, [])
+    )
+    store.get_related_concepts_with_types_direct.side_effect = lambda iid: (
+        _related_by_internal_id.get(iid, [])
+    )
+
     return store
 
 
@@ -384,26 +408,26 @@ class TestSlugifyEdgeCases:
 
 
 # ---------------------------------------------------------------------------
-# Tests: _sanitize_filename
+# Tests: _safe_filename
 # ---------------------------------------------------------------------------
 
 
-class TestSanitizeFilename:
+class TestSafeFilename:
     def test_normal_doc_id(self):
-        assert _sanitize_filename("my_book_123") == "my_book_123"
+        assert _safe_filename("my_book_123") == "my_book_123"
 
     def test_path_traversal_stripped(self):
-        result = _sanitize_filename("../../etc/passwd")
+        result = _safe_filename("../../etc/passwd")
         assert ".." not in result
         assert "/" not in result
 
     def test_special_chars_replaced(self):
-        result = _sanitize_filename("book/with spaces & stuff")
+        result = _safe_filename("book/with spaces & stuff")
         assert "/" not in result
         assert " " not in result
 
     def test_truncation(self):
-        result = _sanitize_filename("a" * 200)
+        result = _safe_filename("a" * 200)
         assert len(result) <= 100
 
 
@@ -480,11 +504,11 @@ class TestDistillEntryPoint:
 
 
 # ---------------------------------------------------------------------------
-# Tests: _rank_concepts caches _related
+# Tests: _rank_concepts two-phase ranking
 # ---------------------------------------------------------------------------
 
 
-class TestRankConceptsCaching:
+class TestRankConceptsTwoPhase:
     @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
     @patch("src.distiller.distiller.instructor")
     def test_related_data_cached_on_ranked_concepts(self, mock_instructor, mock_store):
@@ -501,15 +525,67 @@ class TestRankConceptsCaching:
     @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
     @patch("src.distiller.distiller.instructor")
     def test_build_prerequisites_uses_cached_related(self, mock_instructor, mock_store):
-        """_build_prerequisites should not call get_related_concepts_with_types."""
+        """_build_prerequisites should not call any store methods."""
         distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
         concepts = mock_store.list_concepts.return_value
         ranked = distiller._rank_concepts(concepts, top_k=5)
 
-        # Reset call count after ranking
-        mock_store.get_related_concepts_with_types.reset_mock()
+        # Reset call counts after ranking
+        mock_store.count_concept_edges_direct.reset_mock()
+        mock_store.get_related_concepts_with_types_direct.reset_mock()
 
         distiller._build_prerequisites(ranked)
 
         # Should not have made any additional calls
-        mock_store.get_related_concepts_with_types.assert_not_called()
+        mock_store.count_concept_edges_direct.assert_not_called()
+        mock_store.get_related_concepts_with_types_direct.assert_not_called()
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_phase1_counts_all_concepts(self, mock_instructor, mock_store):
+        """Phase 1 should call count_concept_edges_direct for all concepts."""
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        distiller._rank_concepts(concepts, top_k=2)
+
+        # count_concept_edges_direct called for all 5 concepts
+        assert mock_store.count_concept_edges_direct.call_count == 5
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_phase2_fetches_only_top_k(self, mock_instructor, mock_store):
+        """Phase 2 should call get_related_concepts_with_types_direct only for top_k."""
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=2)
+
+        # Only 2 full fetches (top_k=2), not 5
+        assert mock_store.get_related_concepts_with_types_direct.call_count == 2
+        assert len(ranked) == 2
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_ranked_by_connection_count(self, mock_instructor, mock_store):
+        """Concepts should be ranked by connection count descending."""
+        distiller = TextbookDistiller(mock_store, provider="openai/gp-4o-mini")
+        concepts = mock_store.list_concepts.return_value
+        ranked = distiller._rank_concepts(concepts, top_k=3)
+
+        counts = [c["_connection_count"] for c in ranked]
+        assert counts == sorted(counts, reverse=True)
+        # FIFO and EOQ have 2 connections each, Safety Stock has 1
+        assert ranked[0]["_connection_count"] >= ranked[-1]["_connection_count"]
+
+    @patch("src.distiller.distiller.INSTRUCTOR_AVAILABLE", True)
+    @patch("src.distiller.distiller.instructor")
+    def test_concepts_without_internal_id_skipped(self, mock_instructor, mock_store):
+        """Concepts without 'id' field should get count 0, not raise."""
+        distiller = TextbookDistiller(mock_store, provider="openai/gpt-4o-mini")
+        concepts = [
+            {"concept_id": "no-id", "name": "No ID Concept"},  # Missing "id"
+            *mock_store.list_concepts.return_value,
+        ]
+        ranked = distiller._rank_concepts(concepts, top_k=3)
+
+        # Should still produce results without error
+        assert len(ranked) == 3


### PR DESCRIPTION
## Summary
- **Fix N+1 query**: `_rank_concepts()` was calling `get_related_concepts_with_types()` for every concept (~2000 per doc, ~8 HTTP calls each = ~16,000 total) but only keeping top 20. Refactored to two-phase: count edges concurrently for all concepts (Phase 1), then fetch full relationship data only for top_k (Phase 2). ~10x wall-clock speedup.
- **Fix `_get_data_size` bug**: Function used `rglob("*")` which only works on directories — calling it on the tarball file returned "0 B". Now handles both files and directories.
- **Remove dead code**: `_sanitize_filename()` in `distiller.py` was identical to `_safe_filename()` in `distill.py` and never called. Removed it.
- **Eliminate repeated computation**: `tool_catalog_text` was built identically in both `_generate_identity()` and `_generate_examples()`. Hoisted to module-level `TOOL_CATALOG_TEXT` constant.

## Changes
| File | Change |
|------|--------|
| `src/storage/client.py` | Add `count_concept_edges_direct()` and `get_related_concepts_with_types_direct()` — take internal Helix IDs directly, skip `get_concept()` lookup |
| `src/distiller/distiller.py` | Refactor `_rank_concepts()` to two-phase + `ThreadPoolExecutor(max_workers=10)`. Remove dead `_sanitize_filename`, hoist `TOOL_CATALOG_TEXT` |
| `src/cli/commands/db.py` | Fix `_get_data_size` to handle files, extract `_format_size` helper |
| `tests/test_distiller.py` | Add internal IDs to fixtures, mock new `_direct` methods, add 4 new two-phase assertions |

## Performance Impact
| Metric | Before | After |
|--------|--------|-------|
| HTTP calls (ranking) | ~16,000 sequential | ~14,140 concurrent |
| Wall-clock (10 workers) | ~16,000 batches | ~1,400 batches |
| Memory (_related data) | stored for 2000 concepts | stored for 20 concepts |

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_distiller.py -v` — 33 tests pass
- [x] `PYTHONPATH=. pytest tests/test_db_sync.py -v` — 17 tests pass
- [ ] Manual: `kidkazz distill generate <doc_id> --top-k 5 -v` (requires Helix-DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File and directory sizes now display in human-readable units (KB/MB/GB) and report tarball sizes correctly.

* **Performance**
  * Faster concept ranking via concurrent counting and reduced redundant data fetching.

* **Tests**
  * Updated tests to validate ranking behavior, filename safety, and new traversal/counting logic.

* **Chores**
  * Added ignore rules for generated graph/visualization files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->