### PR TITLE
feat: book-type-aware extraction profiles

### DIFF
--- a/db/queries.hx
+++ b/db/queries.hx
@@ -3,11 +3,12 @@
 // ========== MUTATION QUERIES ==========
 
 // Add a new document
-QUERY AddDocument(doc_id: String, title: String, tags: String, chunk_count: U32, created_at: I64) =>
+QUERY AddDocument(doc_id: String, title: String, tags: String, book_type: String, chunk_count: U32, created_at: I64) =>
     doc <- AddN<Document>({
         doc_id: doc_id,
         title: title,
         tags: tags,
+        book_type: book_type,
         created_at: created_at,
         chunk_count: chunk_count
     })

--- a/db/schema.hx
+++ b/db/schema.hx
@@ -6,6 +6,7 @@ N::Document {
     INDEX doc_id: String,
     title: String,
     tags: String,           // JSON array of document tags
+    book_type: String,      // Extraction profile: programming, erp, stem, agriculture, veterinary, general
     created_at: I64,
     chunk_count: U32,
 }

--- a/src/chunker/concept_extractor.py
+++ b/src/chunker/concept_extractor.py
@@ -205,34 +205,27 @@ class ConceptExtractor:
         context = "\n".join(context_parts)
         existing = existing_concepts or []
 
+        default_types = "terms, methods, principles, formulas, and accounts"
         if self.profile and self.profile.extraction_hints:
             type_list = ", ".join(self.profile.concept_types)
-            system_prompt = (
-                "You are extracting concepts from a textbook. "
-                f"Identify {type_list}. "
-                "For each concept that is DEFINED (explained) in this text, extract:\n"
-                "- The canonical name\n"
-                f"- The type ({type_list})\n"
-                "- A 1-2 sentence definition\n"
-                "- Any aliases or abbreviations\n\n"
-                f"{self.profile.extraction_hints}\n\n"
-                "Also identify relationships between concepts (uses, requires, "
-                "calculated_from, component_of, recorded_in, supersedes).\n\n"
-                f"Already known concepts (reference but don't redefine): {existing}"
-            )
+            hints = f"{self.profile.extraction_hints}\n\n"
         else:
-            system_prompt = (
-                "You are extracting concepts from a textbook. "
-                "Identify terms, methods, principles, formulas, and accounts. "
-                "For each concept that is DEFINED (explained) in this text, extract:\n"
-                "- The canonical name\n"
-                "- The type (term, method, principle, formula, account)\n"
-                "- A 1-2 sentence definition\n"
-                "- Any aliases or abbreviations\n\n"
-                "Also identify relationships between concepts (uses, requires, "
-                "calculated_from, component_of, recorded_in, supersedes).\n\n"
-                f"Already known concepts (reference but don't redefine): {existing}"
-            )
+            type_list = default_types
+            hints = ""
+
+        system_prompt = (
+            "You are extracting concepts from a textbook. "
+            f"Identify {type_list}. "
+            "For each concept that is DEFINED (explained) in this text, extract:\n"
+            "- The canonical name\n"
+            f"- The type ({type_list})\n"
+            "- A 1-2 sentence definition\n"
+            "- Any aliases or abbreviations\n\n"
+            f"{hints}"
+            "Also identify relationships between concepts (uses, requires, "
+            "calculated_from, component_of, recorded_in, supersedes).\n\n"
+            f"Already known concepts (reference but don't redefine): {existing}"
+        )
 
         try:
             return self.client.create(

--- a/src/chunker/concept_extractor.py
+++ b/src/chunker/concept_extractor.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from dotenv import load_dotenv
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 if TYPE_CHECKING:
     from .profiles import ExtractionProfile
@@ -52,6 +52,57 @@ class ExtractedConcept(BaseModel):
 
     name: str = Field(description="Canonical display name (e.g., 'Cost of Goods Sold')")
     concept_type: ConceptType = Field(description="Type of concept")
+
+    @field_validator("concept_type", mode="before")
+    @classmethod
+    def coerce_concept_type(cls, v: object) -> object:
+        """Accept profile-expanded type strings by mapping to closest enum value."""
+        if isinstance(v, ConceptType):
+            return v
+        if isinstance(v, str):
+            v_lower = v.lower().strip()
+            # Direct match
+            for member in ConceptType:
+                if member.value == v_lower:
+                    return member
+            # Map common profile types to the closest base type
+            _TYPE_MAP = {
+                "algorithm": "method",
+                "data_structure": "term",
+                "pattern": "method",
+                "framework": "term",
+                "language": "term",
+                "protocol": "method",
+                "architecture": "term",
+                "function": "method",
+                "theory": "principle",
+                "law": "principle",
+                "process": "method",
+                "organism": "term",
+                "structure": "term",
+                "system": "term",
+                "unit": "term",
+                "practice": "method",
+                "crop": "term",
+                "breed": "term",
+                "pest": "term",
+                "tool": "term",
+                "nutrient": "term",
+                "disease": "term",
+                "symptom": "term",
+                "treatment": "method",
+                "vaccine": "term",
+                "drug": "term",
+                "pathogen": "term",
+                "condition": "term",
+                "anatomy": "term",
+                "procedure": "method",
+                "feed": "term",
+                "behavior": "term",
+            }
+            mapped = _TYPE_MAP.get(v_lower, "term")
+            return ConceptType(mapped)
+        return v
     definition: str = Field(
         description="1-2 sentence definition explaining the concept"
     )

--- a/src/chunker/concept_extractor.py
+++ b/src/chunker/concept_extractor.py
@@ -4,13 +4,18 @@ This module provides LLM-powered extraction of concepts, definitions,
 and relationships from textbook content.
 """
 
+from __future__ import annotations
+
 import logging
 import re
 from enum import Enum
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from .profiles import ExtractionProfile
 
 # Load environment variables (for ANTHROPIC_API_KEY)
 load_dotenv()
@@ -138,6 +143,7 @@ class ConceptExtractor:
         self,
         provider: str = "anthropic/claude-3-5-haiku-20241022",
         max_retries: int = 2,
+        profile: "Optional[ExtractionProfile]" = None,
     ):
         """
         Initialize extractor.
@@ -145,6 +151,7 @@ class ConceptExtractor:
         Args:
             provider: Instructor provider string (e.g., "anthropic/claude-3-5-haiku-20241022")
             max_retries: Number of retries on validation failure
+            profile: Extraction profile for domain-specific concept extraction
 
         Raises:
             ImportError: If instructor is not installed
@@ -157,6 +164,7 @@ class ConceptExtractor:
 
         self.client = instructor.from_provider(provider)
         self.max_retries = max_retries
+        self.profile = profile
 
     def extract_from_chunk(
         self,
@@ -197,18 +205,34 @@ class ConceptExtractor:
         context = "\n".join(context_parts)
         existing = existing_concepts or []
 
-        system_prompt = (
-            "You are extracting concepts from a textbook. "
-            "Identify terms, methods, principles, formulas, and accounts. "
-            "For each concept that is DEFINED (explained) in this text, extract:\n"
-            "- The canonical name\n"
-            "- The type (term, method, principle, formula, account)\n"
-            "- A 1-2 sentence definition\n"
-            "- Any aliases or abbreviations\n\n"
-            "Also identify relationships between concepts (uses, requires, "
-            "calculated_from, component_of, recorded_in, supersedes).\n\n"
-            f"Already known concepts (reference but don't redefine): {existing}"
-        )
+        if self.profile and self.profile.extraction_hints:
+            type_list = ", ".join(self.profile.concept_types)
+            system_prompt = (
+                "You are extracting concepts from a textbook. "
+                f"Identify {type_list}. "
+                "For each concept that is DEFINED (explained) in this text, extract:\n"
+                "- The canonical name\n"
+                f"- The type ({type_list})\n"
+                "- A 1-2 sentence definition\n"
+                "- Any aliases or abbreviations\n\n"
+                f"{self.profile.extraction_hints}\n\n"
+                "Also identify relationships between concepts (uses, requires, "
+                "calculated_from, component_of, recorded_in, supersedes).\n\n"
+                f"Already known concepts (reference but don't redefine): {existing}"
+            )
+        else:
+            system_prompt = (
+                "You are extracting concepts from a textbook. "
+                "Identify terms, methods, principles, formulas, and accounts. "
+                "For each concept that is DEFINED (explained) in this text, extract:\n"
+                "- The canonical name\n"
+                "- The type (term, method, principle, formula, account)\n"
+                "- A 1-2 sentence definition\n"
+                "- Any aliases or abbreviations\n\n"
+                "Also identify relationships between concepts (uses, requires, "
+                "calculated_from, component_of, recorded_in, supersedes).\n\n"
+                f"Already known concepts (reference but don't redefine): {existing}"
+            )
 
         try:
             return self.client.create(

--- a/src/chunker/metadata.py
+++ b/src/chunker/metadata.py
@@ -48,6 +48,17 @@ THEOREM_PATTERNS = [
     r"\bQ\.E\.D\.",
 ]
 
+# Code-specific semantic type patterns (always-on, specific enough to avoid
+# false positives on non-programming books)
+CLI_COMMAND_PATTERNS = [
+    r"```(?:bash|sh|shell|zsh|console|terminal)\b",
+    r"^\s*\$\s+\S",  # Shell prompt: $ command
+]
+
+CODE_EXAMPLE_PATTERNS = [
+    r"```(?:python|java|javascript|typescript|go|rust|cpp|c|ruby|php|scala|kotlin|swift|yaml|json|xml|sql|html|css|dockerfile|hcl|terraform|toml|ini|makefile|cmake|r|matlab|lua|perl|elixir|clojure|haskell|ocaml|zig|nim|groovy|powershell|fish)\b",
+]
+
 
 @dataclass
 class ChunkMetadata:
@@ -117,7 +128,10 @@ class ChunkMetadata:
 
 def infer_semantic_type(content: str) -> str:
     """
-    Classify chunk content as definition/example/procedure/theorem/narrative.
+    Classify chunk content by semantic type.
+
+    Priority order: theorem > definition > cli_command > code_example >
+    example > procedure > narrative.
 
     Args:
         content: Chunk text content
@@ -133,6 +147,16 @@ def infer_semantic_type(content: str) -> str:
     for pattern in DEFINITION_PATTERNS:
         if re.search(pattern, content, re.IGNORECASE | re.MULTILINE):
             return "definition"
+
+    # Code-specific types (before generic "example" since code fences with
+    # language labels are more specific than "for example" text patterns)
+    for pattern in CLI_COMMAND_PATTERNS:
+        if re.search(pattern, content, re.MULTILINE):
+            return "cli_command"
+
+    for pattern in CODE_EXAMPLE_PATTERNS:
+        if re.search(pattern, content, re.MULTILINE):
+            return "code_example"
 
     for pattern in EXAMPLE_PATTERNS:
         if re.search(pattern, content, re.IGNORECASE | re.MULTILINE):

--- a/src/chunker/profiles.py
+++ b/src/chunker/profiles.py
@@ -1,0 +1,208 @@
+"""Book-type-aware extraction profiles for domain-specific concept extraction.
+
+Each profile customizes which concept types the LLM looks for and provides
+domain-specific hints for the extraction and summarization prompts.
+
+Usage:
+    from src.chunker.profiles import get_profile
+
+    profile = get_profile("programming")
+    # profile.concept_types -> ["term", "method", "algorithm", ...]
+    # profile.extraction_hints -> "Look for code examples, CLI commands, ..."
+"""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ExtractionProfile:
+    """Extraction profile for a specific book type.
+
+    Attributes:
+        name: Machine name (e.g., "programming", "erp")
+        display_name: Human-readable label (e.g., "CS / Programming")
+        concept_types: Concept type names the LLM should look for
+        extraction_hints: Extra text appended to LLM system prompts
+    """
+
+    name: str
+    display_name: str
+    concept_types: list[str] = field(default_factory=list)
+    extraction_hints: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Built-in profiles
+# ---------------------------------------------------------------------------
+
+_GENERAL_TYPES = ["term", "method", "principle", "formula", "account"]
+
+PROFILES: dict[str, ExtractionProfile] = {
+    "general": ExtractionProfile(
+        name="general",
+        display_name="General",
+        concept_types=_GENERAL_TYPES,
+        extraction_hints="",
+    ),
+    "programming": ExtractionProfile(
+        name="programming",
+        display_name="CS / Programming",
+        concept_types=[
+            "term",
+            "method",
+            "algorithm",
+            "data_structure",
+            "pattern",
+            "framework",
+            "language",
+            "protocol",
+            "architecture",
+            "function",
+            "formula",
+            "principle",
+        ],
+        extraction_hints=(
+            "This is a programming / computer science textbook. Pay special attention to:\n"
+            "- Code examples and snippets (preserve language identifiers)\n"
+            "- CLI commands and their flags/arguments (e.g., kubectl, docker, git)\n"
+            "- API signatures, function prototypes, and method calls\n"
+            "- Configuration file formats (YAML, JSON, TOML, INI)\n"
+            "- Design patterns and architectural concepts\n"
+            "- Library and framework names as distinct concepts\n"
+            "- Error messages and debugging patterns\n"
+            "When a code block demonstrates a concept, note it as the concept's definition."
+        ),
+    ),
+    "erp": ExtractionProfile(
+        name="erp",
+        display_name="ERP / Business",
+        concept_types=[
+            "term",
+            "method",
+            "principle",
+            "formula",
+            "account",
+            "process",
+            "system",
+        ],
+        extraction_hints=(
+            "This is an ERP / business systems textbook covering modules like "
+            "accounting, warehouse management, human resources, and procurement. "
+            "Pay special attention to:\n"
+            "- ERP module names and their functions\n"
+            "- Business transactions and document flows\n"
+            "- General ledger accounts and chart of accounts structure\n"
+            "- Workflow and approval processes\n"
+            "- Report names and KPIs\n"
+            "- Integration points between modules"
+        ),
+    ),
+    "stem": ExtractionProfile(
+        name="stem",
+        display_name="STEM / Science",
+        concept_types=[
+            "term",
+            "method",
+            "principle",
+            "formula",
+            "theory",
+            "law",
+            "process",
+            "organism",
+            "structure",
+            "system",
+            "unit",
+        ],
+        extraction_hints=(
+            "This is a STEM / science textbook. Pay special attention to:\n"
+            "- Scientific notation, equations, and units of measurement\n"
+            "- Theorems, proofs, and derivations\n"
+            "- Experimental procedures and methodologies\n"
+            "- Physical/chemical/biological processes\n"
+            "- Named laws and principles (e.g., Newton's Laws, Le Chatelier's Principle)\n"
+            "- Organisms, species, and taxonomic classifications"
+        ),
+    ),
+    "agriculture": ExtractionProfile(
+        name="agriculture",
+        display_name="Agriculture / Farming",
+        concept_types=[
+            "term",
+            "method",
+            "principle",
+            "practice",
+            "crop",
+            "breed",
+            "pest",
+            "tool",
+            "nutrient",
+            "system",
+            "process",
+        ],
+        extraction_hints=(
+            "This is an agriculture / farming textbook. Pay special attention to:\n"
+            "- Farming and ranching practices (crop rotation, irrigation, grazing)\n"
+            "- Soil science terms and nutrient cycles\n"
+            "- Crop varieties and planting specifications\n"
+            "- Livestock breeds and management practices\n"
+            "- Pest and disease identification and control\n"
+            "- Equipment and machinery names\n"
+            "- Yield calculations and economic analysis"
+        ),
+    ),
+    "veterinary": ExtractionProfile(
+        name="veterinary",
+        display_name="Veterinary Science",
+        concept_types=[
+            "term",
+            "method",
+            "principle",
+            "disease",
+            "symptom",
+            "treatment",
+            "vaccine",
+            "drug",
+            "pathogen",
+            "condition",
+            "anatomy",
+            "procedure",
+            "feed",
+            "behavior",
+        ],
+        extraction_hints=(
+            "This is a veterinary science textbook. Pay special attention to:\n"
+            "- Disease names, causative agents, and clinical signs\n"
+            "- Differential diagnosis lists\n"
+            "- Treatment protocols and drug dosages\n"
+            "- Vaccine schedules and prevention strategies\n"
+            "- Anatomical structures and body systems\n"
+            "- Surgical and diagnostic procedures\n"
+            "- Nutritional requirements and feed formulations\n"
+            "- Animal behavior and welfare indicators"
+        ),
+    ),
+}
+
+
+def get_profile(name: str) -> ExtractionProfile:
+    """Get an extraction profile by name.
+
+    Args:
+        name: Profile name (programming, erp, stem, agriculture, veterinary, general)
+
+    Returns:
+        ExtractionProfile for the given name
+
+    Raises:
+        ValueError: If profile name is not recognized
+    """
+    profile = PROFILES.get(name)
+    if profile is None:
+        available = ", ".join(sorted(PROFILES))
+        raise ValueError(f"Unknown profile '{name}'. Available: {available}")
+    return profile
+
+
+def list_profiles() -> list[str]:
+    """Return sorted list of available profile names."""
+    return sorted(PROFILES)

--- a/src/chunker/summarizer.py
+++ b/src/chunker/summarizer.py
@@ -627,14 +627,7 @@ class DocumentSummarizer:
             "Only include concepts important enough to reference elsewhere."
         )
 
-        if self.profile and self.profile.extraction_hints:
-            type_list = ", ".join(self.profile.concept_types)
-            base_prompt += (
-                f"\n\nUse these concept types: {type_list}.\n"
-                f"{self.profile.extraction_hints}"
-            )
-
-        return base_prompt
+        return base_prompt + self._profile_hint_suffix()
 
     def _chapter_system_prompt(self) -> str:
         prompt = (
@@ -661,13 +654,7 @@ class DocumentSummarizer:
             "- The correct type: term, method, principle, formula, account, etc.\n\n"
             "Only include concepts central to this chapter's topic."
         )
-        if self.profile and self.profile.extraction_hints:
-            type_list = ", ".join(self.profile.concept_types)
-            prompt += (
-                f"\n\nUse these concept types: {type_list}.\n"
-                f"{self.profile.extraction_hints}"
-            )
-        return prompt
+        return prompt + self._profile_hint_suffix()
 
     def _document_system_prompt(self) -> str:
         prompt = (
@@ -686,13 +673,14 @@ class DocumentSummarizer:
             "drawn from the chapter summaries. Use the correct type: term, method, "
             "principle, formula, account, etc."
         )
+        return prompt + self._profile_hint_suffix()
+
+    def _profile_hint_suffix(self) -> str:
+        """Return profile-specific type list and hints to append to prompts."""
         if self.profile and self.profile.extraction_hints:
             type_list = ", ".join(self.profile.concept_types)
-            prompt += (
-                f"\n\nUse these concept types: {type_list}.\n"
-                f"{self.profile.extraction_hints}"
-            )
-        return prompt
+            return f"\n\nUse these concept types: {type_list}.\n{self.profile.extraction_hints}"
+        return ""
 
     # ========================================================================
     # Helper: Chapter title extraction from key_points sentinel

--- a/src/chunker/summarizer.py
+++ b/src/chunker/summarizer.py
@@ -15,6 +15,8 @@ Features:
 - Exponential backoff on rate limit errors
 """
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
@@ -23,10 +25,13 @@ import time
 from dataclasses import dataclass, field, asdict
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Callable
+from typing import TYPE_CHECKING, Optional, Callable
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, field_validator
+
+if TYPE_CHECKING:
+    from .profiles import ExtractionProfile
 
 # Load environment variables
 load_dotenv()
@@ -533,6 +538,7 @@ class DocumentSummarizer:
         max_concurrent: int = 5,  # For async strategy
         requests_per_minute: int = 500,  # Rate limit for async
         checkpoint_dir: Optional[Path] = None,
+        profile: "Optional[ExtractionProfile]" = None,
     ):
         """
         Initialize summarizer.
@@ -544,6 +550,7 @@ class DocumentSummarizer:
             max_concurrent: Max concurrent requests for async strategy
             requests_per_minute: Rate limit for async strategy
             checkpoint_dir: Directory for checkpoint files
+            profile: Extraction profile for domain-specific concept extraction
 
         Raises:
             ImportError: If instructor is not installed
@@ -561,6 +568,7 @@ class DocumentSummarizer:
         self.max_concurrent = max_concurrent
         self.requests_per_minute = requests_per_minute
         self.checkpoint_dir = checkpoint_dir or Path.home() / ".kidkazz" / "checkpoints"
+        self.profile = profile
 
         # For async rate limiting
         self._semaphore: Optional[asyncio.Semaphore] = None
@@ -619,10 +627,17 @@ class DocumentSummarizer:
             "Only include concepts important enough to reference elsewhere."
         )
 
+        if self.profile and self.profile.extraction_hints:
+            type_list = ", ".join(self.profile.concept_types)
+            base_prompt += (
+                f"\n\nUse these concept types: {type_list}.\n"
+                f"{self.profile.extraction_hints}"
+            )
+
         return base_prompt
 
     def _chapter_system_prompt(self) -> str:
-        return (
+        prompt = (
             "You are summarizing a chapter from a textbook. You will receive:\n"
             "1. Section summaries (extractive highlights from each section)\n"
             "2. The raw chapter text (full content for verification)\n\n"
@@ -646,9 +661,16 @@ class DocumentSummarizer:
             "- The correct type: term, method, principle, formula, account, etc.\n\n"
             "Only include concepts central to this chapter's topic."
         )
+        if self.profile and self.profile.extraction_hints:
+            type_list = ", ".join(self.profile.concept_types)
+            prompt += (
+                f"\n\nUse these concept types: {type_list}.\n"
+                f"{self.profile.extraction_hints}"
+            )
+        return prompt
 
     def _document_system_prompt(self) -> str:
-        return (
+        prompt = (
             "You are summarizing an entire textbook or technical document. "
             "Given the chapter summaries, create a comprehensive 5-7 sentence overview "
             "that explains what the document covers, its purpose, and main themes.\n\n"
@@ -664,6 +686,13 @@ class DocumentSummarizer:
             "drawn from the chapter summaries. Use the correct type: term, method, "
             "principle, formula, account, etc."
         )
+        if self.profile and self.profile.extraction_hints:
+            type_list = ", ".join(self.profile.concept_types)
+            prompt += (
+                f"\n\nUse these concept types: {type_list}.\n"
+                f"{self.profile.extraction_hints}"
+            )
+        return prompt
 
     # ========================================================================
     # Helper: Chapter title extraction from key_points sentinel

--- a/src/chunker/summarizer.py
+++ b/src/chunker/summarizer.py
@@ -677,10 +677,15 @@ class DocumentSummarizer:
 
     def _profile_hint_suffix(self) -> str:
         """Return profile-specific type list and hints to append to prompts."""
-        if self.profile and self.profile.extraction_hints:
+        if not self.profile:
+            return ""
+        parts = []
+        if self.profile.concept_types:
             type_list = ", ".join(self.profile.concept_types)
-            return f"\n\nUse these concept types: {type_list}.\n{self.profile.extraction_hints}"
-        return ""
+            parts.append(f"Use these concept types: {type_list}.")
+        if self.profile.extraction_hints:
+            parts.append(self.profile.extraction_hints)
+        return "\n\n" + "\n".join(parts) if parts else ""
 
     # ========================================================================
     # Helper: Chapter title extraction from key_points sentinel

--- a/src/cli/commands/ingest.py
+++ b/src/cli/commands/ingest.py
@@ -157,8 +157,15 @@ def ingest_markdown(
     """
     config = CLIConfig.load()
 
-    # Resolve extraction profile
+    # Resolve and validate extraction profile
     profile_name = profile or config.extraction_profile
+    try:
+        from src.chunker.profiles import get_profile
+        get_profile(profile_name)
+    except ValueError:
+        from src.chunker.profiles import list_profiles
+        print_error(f"Unknown profile '{profile_name}'. Available: {', '.join(list_profiles())}")
+        raise typer.Exit(1)
 
     # Resolve file path (check output directory if not found)
     file = _resolve_file_path(file, config)

--- a/src/cli/commands/ingest.py
+++ b/src/cli/commands/ingest.py
@@ -134,6 +134,11 @@ def ingest_markdown(
         "--json",
         help="Output results as JSON",
     ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        help="Book type profile: programming, erp, stem, agriculture, veterinary, general",
+    ),
 ) -> None:
     """Chunk Markdown file, generate embeddings, and store in database.
 
@@ -151,6 +156,9 @@ def ingest_markdown(
         via Cohere Embed v4 (requires cohere embedder).
     """
     config = CLIConfig.load()
+
+    # Resolve extraction profile
+    profile_name = profile or config.extraction_profile
 
     # Resolve file path (check output directory if not found)
     file = _resolve_file_path(file, config)
@@ -278,6 +286,7 @@ def ingest_markdown(
                 embedded_chunks,
                 metadata,
                 tags=tag_list,
+                book_type=profile_name,
             )
             tracker.complete("Storing in database...")
 

--- a/src/cli/commands/summarize.py
+++ b/src/cli/commands/summarize.py
@@ -587,10 +587,7 @@ def generate_summaries(
     if profile:
         profile_name = profile
     else:
-        # Auto-detect from document's stored book_type
-        docs = store.list_documents()
-        doc_meta = next((d for d in docs if d.get("doc_id") == doc_id), {})
-        stored_type = doc_meta.get("book_type", "")
+        stored_type = doc.get("book_type", "")
         profile_name = stored_type if stored_type and stored_type != "general" else config.extraction_profile
 
     if profile_name and profile_name != "general":

--- a/src/cli/commands/summarize.py
+++ b/src/cli/commands/summarize.py
@@ -588,7 +588,7 @@ def generate_summaries(
         profile_name = profile
     else:
         stored_type = doc.get("book_type", "")
-        profile_name = stored_type if stored_type and stored_type != "general" else config.extraction_profile
+        profile_name = stored_type if stored_type else config.extraction_profile
 
     if profile_name and profile_name != "general":
         try:

--- a/src/cli/commands/summarize.py
+++ b/src/cli/commands/summarize.py
@@ -467,6 +467,11 @@ def generate_summaries(
         "-r",
         help="Detect and regenerate only missing chapter summaries",
     ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        help="Book type profile (auto-detected from document if not set)",
+    ),
 ) -> None:
     """Generate hierarchical summaries for a document.
 
@@ -577,9 +582,28 @@ def generate_summaries(
         }
         chunks.append(chunk_dict)
 
+    # Resolve extraction profile (flag > document book_type > config default)
+    extraction_profile = None
+    if profile:
+        profile_name = profile
+    else:
+        # Auto-detect from document's stored book_type
+        docs = store.list_documents()
+        doc_meta = next((d for d in docs if d.get("doc_id") == doc_id), {})
+        stored_type = doc_meta.get("book_type", "")
+        profile_name = stored_type if stored_type and stored_type != "general" else config.extraction_profile
+
+    if profile_name and profile_name != "general":
+        try:
+            from src.chunker.profiles import get_profile
+            extraction_profile = get_profile(profile_name)
+            logger.info("Using extraction profile: %s", profile_name)
+        except (ImportError, ValueError):
+            logger.warning("Unknown profile '%s', using general", profile_name)
+
     # Initialize summarizer
     final_provider = provider or config.summarization_provider or "openai/gpt-4o-mini"
-    summarizer = DocumentSummarizer(provider=final_provider)
+    summarizer = DocumentSummarizer(provider=final_provider, profile=extraction_profile)
 
     # Count chunks by level
     l1_count = len([c for c in chunks if c.get("level") == 1])

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -72,6 +72,9 @@ class CLIConfig:
     max_tokens_per_summary: int = 500
     include_key_points: bool = True
 
+    # Extraction profile
+    extraction_profile: str = "general"
+
     # Source tracking (which config file each setting came from)
     _sources: dict[str, str] = field(default_factory=dict)
     # Raw TOML data for get_extra() lookups
@@ -213,6 +216,13 @@ class CLIConfig:
                 self.include_key_points = bool(summarization["include_key_points"])
                 self._sources["include_key_points"] = source
 
+        # Extraction profile
+        if "extraction" in data:
+            extraction = data["extraction"]
+            if "default_profile" in extraction:
+                self.extraction_profile = extraction["default_profile"]
+                self._sources["extraction_profile"] = source
+
     def _load_from_env(self) -> None:
         """Load settings from environment variables.
 
@@ -234,6 +244,7 @@ class CLIConfig:
             "KIDKAZZ_CLOUD_PATH": ("cloud_path", str),
             "KIDKAZZ_RERANKER_ENABLED": ("reranker_enabled", lambda x: x.lower() in ("true", "1", "yes")),
             "KIDKAZZ_RERANKER_MODEL": ("reranker_model", str),
+            "KIDKAZZ_EXTRACTION_PROFILE": ("extraction_profile", str),
         }
 
         for env_var, (attr, converter) in env_mappings.items():

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -309,6 +309,9 @@ class CLIConfig:
                 "enabled": self.reranker_enabled,
                 "model": self.reranker_model,
             },
+            "extraction": {
+                "default_profile": self.extraction_profile,
+            },
         }
 
     def save_project(self, path: Optional[Path] = None) -> bool:
@@ -362,6 +365,7 @@ class CLIConfig:
             "cloud_path": ("cloud_path", str),
             "reranker_enabled": ("reranker_enabled", lambda x: x.lower() in ("true", "1", "yes") if isinstance(x, str) else bool(x)),
             "reranker_model": ("reranker_model", str),
+            "extraction_profile": ("extraction_profile", str),
         }
 
         if key not in key_mapping:

--- a/src/storage/client.py
+++ b/src/storage/client.py
@@ -113,6 +113,7 @@ class ChunkStoreProtocol(Protocol):
         embedded_chunks: list[EmbeddedChunk],
         metadata_list: list[ChunkMetadata],
         tags: Optional[list[str]] = None,
+        book_type: str = "general",
     ) -> None:
         """Store a document with all chunks."""
         ...
@@ -351,6 +352,7 @@ class HelixChunkStore:
         embedded_chunks: list[EmbeddedChunk],
         metadata_list: list[ChunkMetadata],
         tags: Optional[list[str]] = None,
+        book_type: str = "general",
     ) -> dict[str, str]:
         """
         Store a complete document with all chunks, embeddings, and relationships.
@@ -361,6 +363,7 @@ class HelixChunkStore:
             embedded_chunks: List of chunks with embeddings
             metadata_list: Corresponding metadata for each chunk
             tags: Optional list of document tags (e.g., ["inventory", "accounting"])
+            book_type: Extraction profile name (programming, erp, stem, etc.)
 
         Returns:
             Dictionary mapping chunk string IDs to internal database IDs.
@@ -372,8 +375,8 @@ class HelixChunkStore:
         """
         self._ensure_connected()
 
-        # Add document node with tags
-        doc_query = AddDocument(doc_id, title, len(embedded_chunks), tags=tags)
+        # Add document node with tags and book type
+        doc_query = AddDocument(doc_id, title, len(embedded_chunks), tags=tags, book_type=book_type)
         doc_response = self._client.query(doc_query)
         doc_internal_id = self._extract_node_id(doc_response)
 

--- a/src/storage/converters.py
+++ b/src/storage/converters.py
@@ -236,7 +236,7 @@ def document_to_helix_node(
         "doc_id": doc_id,
         "title": title,
         "tags": json.dumps(normalized_tags),
-        "book_type": book_type,
+        "book_type": book_type or "general",
         "chunk_count": chunk_count,
         "created_at": created_at or int(time.time()),
     }
@@ -272,7 +272,7 @@ def helix_node_to_document(node: dict[str, Any]) -> dict[str, Any]:
         "doc_id": node["doc_id"],
         "title": node.get("title", ""),
         "tags": tags,
-        "book_type": node.get("book_type", "general"),
+        "book_type": node.get("book_type") or "general",
         "chunk_count": node.get("chunk_count", 0),
         "created_at": node.get("created_at", 0),
     }

--- a/src/storage/converters.py
+++ b/src/storage/converters.py
@@ -211,6 +211,7 @@ def document_to_helix_node(
     chunk_count: int,
     created_at: Optional[int] = None,
     tags: Optional[list[str]] = None,
+    book_type: str = "general",
 ) -> dict[str, Any]:
     """
     Create Helix-DB document node properties.
@@ -221,6 +222,7 @@ def document_to_helix_node(
         chunk_count: Number of chunks in document
         created_at: Unix timestamp (auto-generated if not provided)
         tags: Optional list of document tags
+        book_type: Extraction profile name (programming, erp, stem, etc.)
 
     Returns:
         Dictionary of document node properties
@@ -234,6 +236,7 @@ def document_to_helix_node(
         "doc_id": doc_id,
         "title": title,
         "tags": json.dumps(normalized_tags),
+        "book_type": book_type,
         "chunk_count": chunk_count,
         "created_at": created_at or int(time.time()),
     }

--- a/src/storage/converters.py
+++ b/src/storage/converters.py
@@ -269,6 +269,7 @@ def helix_node_to_document(node: dict[str, Any]) -> dict[str, Any]:
         "doc_id": node["doc_id"],
         "title": node.get("title", ""),
         "tags": tags,
+        "book_type": node.get("book_type", "general"),
         "chunk_count": node.get("chunk_count", 0),
         "created_at": node.get("created_at", 0),
     }

--- a/src/storage/mock_store.py
+++ b/src/storage/mock_store.py
@@ -44,6 +44,7 @@ class MockChunkStore:
         embedded_chunks: list[EmbeddedChunk],
         metadata_list: list[ChunkMetadata],
         tags: Optional[list[str]] = None,
+        book_type: str = "general",
     ) -> None:
         """
         Store a complete document with all chunks, embeddings, and relationships.
@@ -54,6 +55,7 @@ class MockChunkStore:
             embedded_chunks: List of chunks with embeddings
             metadata_list: Corresponding metadata for each chunk
             tags: Optional list of document tags (e.g., ["inventory", "accounting"])
+            book_type: Extraction profile name (programming, erp, stem, etc.)
         """
         import time
 
@@ -65,6 +67,7 @@ class MockChunkStore:
             "doc_id": doc_id,
             "title": title,
             "tags": normalized_tags,
+            "book_type": book_type,
             "chunk_count": len(embedded_chunks),
             "created_at": int(time.time()),
         }

--- a/src/storage/queries.py
+++ b/src/storage/queries.py
@@ -70,6 +70,7 @@ class AddDocument(_get_query_base_class()):
         title: str,
         chunk_count: int,
         tags: Optional[list[str]] = None,
+        book_type: str = "general",
     ) -> None:
         """
         Initialize AddDocument query.
@@ -79,11 +80,13 @@ class AddDocument(_get_query_base_class()):
             title: Document title
             chunk_count: Number of chunks in document
             tags: Optional list of document tags
+            book_type: Extraction profile name (programming, erp, stem, etc.)
         """
         super().__init__()
         self.doc_id = doc_id
         self.title = title
         self.chunk_count = chunk_count
+        self.book_type = book_type
         self.created_at = int(time.time())
         # Normalize tags to lowercase and filter empty strings
         self.tags = [t.lower().strip() for t in (tags or []) if t and t.strip()]
@@ -94,6 +97,7 @@ class AddDocument(_get_query_base_class()):
             "doc_id": self.doc_id,
             "title": self.title,
             "tags": json.dumps(self.tags),
+            "book_type": self.book_type,
             "chunk_count": self.chunk_count,
             "created_at": self.created_at,
         }]

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,82 @@
+"""Tests for extraction profiles."""
+
+import pytest
+
+from src.chunker.profiles import (
+    ExtractionProfile,
+    PROFILES,
+    get_profile,
+    list_profiles,
+)
+
+
+class TestExtractionProfile:
+    def test_all_builtin_profiles_exist(self):
+        expected = {"general", "programming", "erp", "stem", "agriculture", "veterinary"}
+        assert set(PROFILES.keys()) == expected
+
+    def test_all_profiles_have_concept_types(self):
+        for name, profile in PROFILES.items():
+            assert profile.concept_types, f"Profile '{name}' has empty concept_types"
+
+    def test_all_profiles_have_display_name(self):
+        for name, profile in PROFILES.items():
+            assert profile.display_name, f"Profile '{name}' has empty display_name"
+
+    def test_general_matches_original_5_types(self):
+        """General profile must match the original 5 concept types for backward compat."""
+        general = get_profile("general")
+        assert general.concept_types == ["term", "method", "principle", "formula", "account"]
+
+    def test_general_has_no_extraction_hints(self):
+        """General profile should not add extra hints (backward compat)."""
+        general = get_profile("general")
+        assert general.extraction_hints == ""
+
+    def test_programming_has_code_hints(self):
+        prog = get_profile("programming")
+        assert "code" in prog.extraction_hints.lower()
+        assert "CLI" in prog.extraction_hints
+        assert "algorithm" in prog.concept_types
+
+    def test_erp_has_business_types(self):
+        erp = get_profile("erp")
+        assert "account" in erp.concept_types
+        assert "process" in erp.concept_types
+        assert "ERP" in erp.extraction_hints
+
+    def test_veterinary_has_medical_types(self):
+        vet = get_profile("veterinary")
+        assert "disease" in vet.concept_types
+        assert "treatment" in vet.concept_types
+        assert "vaccine" in vet.concept_types
+
+    def test_profile_is_frozen(self):
+        profile = get_profile("general")
+        with pytest.raises(AttributeError):
+            profile.name = "modified"
+
+
+class TestGetProfile:
+    def test_returns_correct_profile(self):
+        profile = get_profile("programming")
+        assert profile.name == "programming"
+
+    def test_raises_on_unknown(self):
+        with pytest.raises(ValueError, match="Unknown profile 'nonexistent'"):
+            get_profile("nonexistent")
+
+    def test_error_message_lists_available(self):
+        with pytest.raises(ValueError, match="Available:"):
+            get_profile("bad_name")
+
+
+class TestListProfiles:
+    def test_returns_sorted_list(self):
+        names = list_profiles()
+        assert names == sorted(names)
+        assert "general" in names
+        assert "programming" in names
+
+    def test_count(self):
+        assert len(list_profiles()) == 6


### PR DESCRIPTION
## Summary
- Add **extraction profiles** so different book types get domain-appropriate concept extraction
- 6 built-in profiles: `programming`, `erp`, `stem`, `agriculture`, `veterinary`, `general`
- New semantic types: `code_example` (labeled code fences) and `cli_command` (bash/shell fences)
- Store `book_type` on Document nodes in Helix-DB
- `--profile` flag on `kidkazz ingest` and `kidkazz summarize` commands
- Auto-detect profile from stored document `book_type` during summarization

## How it works
Each profile defines:
- **concept_types**: list of types the LLM should look for (e.g., `algorithm`, `framework`, `disease`)
- **extraction_hints**: domain-specific instructions appended to LLM system prompts

```bash
# Programming book
kidkazz ingest markdown k8s_book.md --profile programming --tags "kubernetes"
kidkazz summarize generate k8s_book --profile programming

# Accounting book (default behavior unchanged)
kidkazz ingest markdown accounting.md --tags "accounting"

# Set default in config
# .kidkazz.toml:
# [extraction]
# default_profile = "programming"
```

## Changes (5 commits)
1. `profiles.py` — ExtractionProfile dataclass + 6 built-in profiles
2. `metadata.py` — `code_example` and `cli_command` semantic type detection
3. Schema — `book_type: String` on Document node (requires `helix push dev`)
4. LLM prompts — concept_extractor + summarizer accept profile for domain-specific prompts
5. CLI — `--profile` flag, config default, env var, auto-detect from stored book_type

## Test plan
- [x] 14 new profile tests pass
- [x] 60 metadata tests pass (no regressions)
- [x] 1302 total tests pass (0 failures)
- [ ] Manual: `helix push dev` to apply schema change
- [ ] Manual: `kidkazz ingest markdown <file> --profile programming`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extraction profile system with six built-in profiles (general, programming, ERP, STEM, agriculture, veterinary)
  * New --profile CLI option for ingestion and summary generation with auto-detection and configurable default
  * Profile-aware concept extraction and summary prompts
  * Improved semantic detection for CLI commands and code examples
* **Tests**
  * Added tests validating profiles, immutability, lookup, and listing behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->