### PR TITLE
feat: procedural skill extraction from textbooks

### DIFF
--- a/db/queries.hx
+++ b/db/queries.hx
@@ -611,3 +611,161 @@ QUERY DropSummaryVector(vector_id: ID) =>
 QUERY DeleteDocumentSummaries(document_id: String) =>
     summaries <- N<Summary>::WHERE(_::{document_id}::EQ(document_id))
     RETURN summaries
+
+// ========== PROCEDURAL SKILLS ==========
+
+// Add a new skill
+QUERY AddSkill(
+    skill_id: String,
+    name: String,
+    goal: String,
+    domain: String,
+    difficulty: String,
+    source_document_id: String,
+    anchor_header: String,
+    source_chunk_ids: String,
+    success_criteria: String,
+    common_failures: String,
+    step_count: U32,
+    has_code: U32,
+    created_at: I64
+) =>
+    skill <- AddN<Skill>({
+        skill_id: skill_id,
+        name: name,
+        goal: goal,
+        domain: domain,
+        difficulty: difficulty,
+        source_document_id: source_document_id,
+        anchor_header: anchor_header,
+        source_chunk_ids: source_chunk_ids,
+        success_criteria: success_criteria,
+        common_failures: common_failures,
+        step_count: step_count,
+        has_code: has_code,
+        created_at: created_at
+    })
+    RETURN skill
+
+// Add a skill step
+QUERY AddSkillStep(
+    step_id: String,
+    skill_id: String,
+    step_number: U32,
+    action: String,
+    code_content: String,
+    code_language: String,
+    expected_output: String,
+    is_optional: U32
+) =>
+    step <- AddN<SkillStep>({
+        step_id: step_id,
+        skill_id: skill_id,
+        step_number: step_number,
+        action: action,
+        code_content: code_content,
+        code_language: code_language,
+        expected_output: expected_output,
+        is_optional: is_optional
+    })
+    RETURN step
+
+// Add vector embedding for a skill
+QUERY AddSkillVector(embedding: [F64], model_name: String, embedding_dim: U32) =>
+    vec <- AddV<SkillVector>(embedding, {
+        model_name: model_name,
+        embedding_dim: embedding_dim
+    })
+    RETURN vec
+
+// Link skill to step
+QUERY LinkHasStep(skill_id: ID, step_id: ID) =>
+    skill <- N<Skill>(skill_id)
+    step <- N<SkillStep>(step_id)
+    AddE<HasStep>::From(skill)::To(step)
+    RETURN skill
+
+// Link skill to prerequisite concept
+QUERY LinkRequiresConcept(skill_id: ID, concept_id: ID) =>
+    skill <- N<Skill>(skill_id)
+    concept <- N<Concept>(concept_id)
+    AddE<RequiresConcept>::From(skill)::To(concept)
+    RETURN skill
+
+// Link skill to produced concept
+QUERY LinkProducesConcept(skill_id: ID, concept_id: ID) =>
+    skill <- N<Skill>(skill_id)
+    concept <- N<Concept>(concept_id)
+    AddE<ProducesConcept>::From(skill)::To(concept)
+    RETURN skill
+
+// Link skill to prerequisite skill
+QUERY LinkRequiresSkill(skill_id: ID, prereq_id: ID) =>
+    skill <- N<Skill>(skill_id)
+    prereq <- N<Skill>(prereq_id)
+    AddE<RequiresSkill>::From(skill)::To(prereq)
+    RETURN skill
+
+// Link skill to its source document
+QUERY LinkSkillDefinedIn(skill_id: ID, doc_id: ID) =>
+    skill <- N<Skill>(skill_id)
+    doc <- N<Document>(doc_id)
+    AddE<SkillDefinedIn>::From(skill)::To(doc)
+    RETURN skill
+
+// Link skill to its embedding
+QUERY LinkSkillVector(skill_id: ID, vector_id: ID) =>
+    skill <- N<Skill>(skill_id)
+    vec <- V<SkillVector>(vector_id)
+    AddE<SkillHasEmbedding>::From(skill)::To(vec)
+    RETURN skill
+
+// Get a skill by its slug
+QUERY GetSkillById(skill_id: String) =>
+    skills <- N<Skill>::WHERE(_::{skill_id}::EQ(skill_id))
+    RETURN skills
+
+// Get a skill by its display name
+QUERY GetSkillByName(name: String) =>
+    skills <- N<Skill>::WHERE(_::{name}::EQ(name))
+    RETURN skills
+
+// Get all steps for a skill (client sorts by step_number)
+QUERY GetSkillSteps(skill_id: String) =>
+    steps <- N<SkillStep>::WHERE(_::{skill_id}::EQ(skill_id))
+    RETURN steps
+
+// Get prerequisite concepts for a skill
+QUERY GetSkillPrerequisiteConcepts(skill_id: ID) =>
+    concepts <- N<Skill>(skill_id)::Out<RequiresConcept>
+    RETURN concepts
+
+// Get produced concepts for a skill
+QUERY GetSkillProducedConcepts(skill_id: ID) =>
+    concepts <- N<Skill>(skill_id)::Out<ProducesConcept>
+    RETURN concepts
+
+// Get prerequisite skills for a skill
+QUERY GetSkillPrerequisiteSkills(skill_id: ID) =>
+    skills <- N<Skill>(skill_id)::Out<RequiresSkill>
+    RETURN skills
+
+// List all skills
+QUERY ListAllSkills() =>
+    skills <- N<Skill>
+    RETURN skills
+
+// List skills for a specific document
+QUERY ListDocumentSkills(source_document_id: String) =>
+    skills <- N<Skill>::WHERE(_::{source_document_id}::EQ(source_document_id))
+    RETURN skills
+
+// Get the skill linked to a vector (for search result processing)
+QUERY GetSkillForVector(vector_id: ID) =>
+    skill <- V<SkillVector>(vector_id)::In<SkillHasEmbedding>
+    RETURN skill
+
+// Vector similarity search on skills
+QUERY SearchSimilarSkills(query_vec: [F64], top_k: U32) =>
+    results <- SearchV<SkillVector>(query_vec, top_k)
+    RETURN results

--- a/db/schema.hx
+++ b/db/schema.hx
@@ -185,3 +185,77 @@ E::SummaryHasEmbedding {
     From: Summary,
     To: SummaryVector,
 }
+
+
+// ========== PROCEDURAL SKILLS ==========
+
+// Skill node: Named, executable procedure extracted from a textbook
+N::Skill {
+    INDEX skill_id: String,            // Slugified canonical name
+    INDEX name: String,                // "Deploy app to Kubernetes"
+    goal: String,                      // What the user accomplishes
+    INDEX domain: String,              // Profile name: programming, erp, etc.
+    difficulty: String,                // beginner | intermediate | advanced
+    INDEX source_document_id: String,  // Document this skill was extracted from
+    anchor_header: String,             // Text of the anchor header
+    source_chunk_ids: String,          // JSON array of chunk_ids spanning the skill
+    success_criteria: String,          // How to verify success
+    common_failures: String,           // JSON array of {symptom, resolution}
+    step_count: U32,
+    has_code: U32,                     // 0/1 — convenience flag
+    created_at: I64,
+}
+
+// SkillStep node: Single ordered step within a skill
+N::SkillStep {
+    INDEX step_id: String,             // {skill_id}_step_{N}
+    INDEX skill_id: String,
+    step_number: U32,
+    action: String,                    // Narrative describing the step
+    code_content: String,              // Verbatim code, empty if none
+    code_language: String,             // "bash", "yaml", "", etc.
+    expected_output: String,
+    is_optional: U32,                  // 0/1
+}
+
+// SkillVector: Embedding for skill semantic search
+V::SkillVector {
+    model_name: String,
+    embedding_dim: U32,
+}
+
+// Skill has steps (ordered via step_number)
+E::HasStep {
+    From: Skill,
+    To: SkillStep,
+}
+
+// Skill requires a concept to be understood first (prerequisite knowledge)
+E::RequiresConcept {
+    From: Skill,
+    To: Concept,
+}
+
+// Skill requires another skill to be learned first
+E::RequiresSkill {
+    From: Skill,
+    To: Skill,
+}
+
+// Skill produces a concept when executed (what it creates)
+E::ProducesConcept {
+    From: Skill,
+    To: Concept,
+}
+
+// Skill was defined in a document
+E::SkillDefinedIn {
+    From: Skill,
+    To: Document,
+}
+
+// Skill has embedding for vector search
+E::SkillHasEmbedding {
+    From: Skill,
+    To: SkillVector,
+}

--- a/src/chunker/skill_synthesizer.py
+++ b/src/chunker/skill_synthesizer.py
@@ -1,0 +1,246 @@
+"""LLM-based enrichment of detected procedural skills.
+
+Takes raw skills produced by `src/chunker/skills.py` (phases A+B) and adds
+LLM-generated metadata:
+
+- Canonical imperative name
+- Goal / success criteria
+- Difficulty
+- Prerequisite concepts (linked to the existing concept graph)
+- Produced concepts
+- Common failure modes
+
+Raw steps from phase B are preserved verbatim — the LLM only enriches the
+surrounding metadata. This keeps code/CLI snippets exactly as the textbook
+wrote them.
+
+Mirrors the summarizer pattern: optional Instructor import, Pydantic models
+for structured output, profile-aware system prompts.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .skills import AssembledSkill, RawStep
+
+if TYPE_CHECKING:
+    from .profiles import ExtractionProfile
+
+logger = logging.getLogger(__name__)
+
+# Optional import for instructor (same pattern as summarizer.py)
+try:
+    import instructor
+
+    INSTRUCTOR_AVAILABLE = True
+except ImportError:
+    instructor = None  # type: ignore[assignment]
+    INSTRUCTOR_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models for LLM output
+# ---------------------------------------------------------------------------
+
+
+class CommonFailure(BaseModel):
+    """A known failure mode for a skill."""
+
+    symptom: str = Field(description="Observable symptom or error message")
+    resolution: str = Field(description="How to resolve or work around the failure")
+
+
+class EnrichedSkillMetadata(BaseModel):
+    """LLM-generated metadata attached to an AssembledSkill.
+
+    Raw steps are NOT part of this model — they come from phase B. This
+    model only carries the metadata the LLM should derive.
+    """
+
+    name: str = Field(
+        description=(
+            "Canonical imperative title, max 8 words "
+            "(e.g., 'Deploy app to Kubernetes', 'Calculate safety stock')."
+        ),
+    )
+    goal: str = Field(
+        description="1 sentence describing what the user accomplishes by executing this skill."
+    )
+    difficulty: Literal["beginner", "intermediate", "advanced"] = Field(
+        description="Approximate difficulty level for someone new to the domain."
+    )
+    success_criteria: str = Field(
+        description="1 sentence describing how to verify the skill executed successfully."
+    )
+    common_failures: list[CommonFailure] = Field(
+        default_factory=list,
+        description="Known failure modes with resolutions (0-4 items).",
+    )
+    prerequisite_concepts: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of concepts that must be understood before attempting this skill. "
+            "Use exact names from the KNOWN CONCEPTS list when possible."
+        ),
+    )
+    prerequisite_skills: list[str] = Field(
+        default_factory=list,
+        description="Names of other skills that should be learned first.",
+    )
+    produces_concepts: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of concepts this skill creates or modifies in the world "
+            "(e.g., 'running pod', 'approved purchase order')."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthesizer
+# ---------------------------------------------------------------------------
+
+
+class SkillSynthesizer:
+    """Enrich AssembledSkills with LLM-generated metadata via Instructor."""
+
+    def __init__(
+        self,
+        provider: str = "openai/gpt-4o-mini",
+        max_retries: int = 2,
+        profile: "Optional[ExtractionProfile]" = None,
+    ) -> None:
+        """
+        Initialize synthesizer.
+
+        Args:
+            provider: Instructor provider string (e.g., "openai/gpt-4o-mini")
+            max_retries: Number of retries on validation failure
+            profile: Extraction profile for domain-specific prompts
+
+        Raises:
+            ImportError: If instructor is not installed
+        """
+        if not INSTRUCTOR_AVAILABLE or instructor is None:
+            raise ImportError(
+                "instructor is not installed. "
+                "Install with: pip install 'kidkazz[concepts]'"
+            )
+        self.provider = provider
+        self.client = instructor.from_provider(provider)
+        self.max_retries = max_retries
+        self.profile = profile
+
+    # ------------------------------------------------------------------
+    # Prompt construction
+    # ------------------------------------------------------------------
+
+    def _system_prompt(self) -> str:
+        base = (
+            "You are analyzing a PROCEDURAL SKILL extracted from a textbook. "
+            "You will be given:\n"
+            "1. An anchor header (e.g., 'How to Deploy an Application')\n"
+            "2. An ordered list of parsed steps with code snippets where present\n"
+            "3. A list of known concepts from the same textbook\n\n"
+            "Your job is to produce structured metadata ABOUT the skill — "
+            "not to rewrite the steps. Steps are already correct. Return:\n"
+            "- A concise imperative name\n"
+            "- The concrete goal the user achieves\n"
+            "- A difficulty estimate\n"
+            "- Success criteria (how to verify it worked)\n"
+            "- Common failures the textbook warns about\n"
+            "- Prerequisite concepts (match exact names from KNOWN CONCEPTS)\n"
+            "- Prerequisite skills\n"
+            "- Produced concepts (what the skill creates)\n\n"
+            "If the textbook doesn't mention something, leave the list empty. "
+            "Do NOT invent prerequisites that aren't implied by the source."
+        )
+        if self.profile and self.profile.extraction_hints:
+            base += f"\n\n{self.profile.extraction_hints}"
+        return base
+
+    def _user_prompt(
+        self,
+        skill: AssembledSkill,
+        known_concepts: list[str],
+    ) -> str:
+        steps_text = "\n".join(self._format_step(s) for s in skill.steps)
+        concepts_text = ", ".join(known_concepts[:100]) if known_concepts else "(none extracted yet)"
+        return (
+            f"ANCHOR HEADER: {skill.boundary.anchor_header}\n\n"
+            f"STEPS:\n{steps_text}\n\n"
+            f"KNOWN CONCEPTS:\n{concepts_text}"
+        )
+
+    @staticmethod
+    def _format_step(step: RawStep) -> str:
+        parts = [f"{step.step_number}. {step.action}"]
+        if step.code_content:
+            lang = step.code_language or ""
+            parts.append(f"   ```{lang}\n{step.code_content}\n   ```")
+        if step.expected_output:
+            parts.append(f"   Output: {step.expected_output}")
+        return "\n".join(parts)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def enrich(
+        self,
+        skill: AssembledSkill,
+        known_concepts: Optional[list[str]] = None,
+    ) -> EnrichedSkillMetadata:
+        """Call the LLM to produce enriched metadata for a single skill.
+
+        Raises the underlying Instructor exception on failure (caller
+        decides how to handle — retry, skip, fall back to defaults).
+        """
+        return self.client.chat.completions.create(
+            model=self.provider.split("/", 1)[-1],
+            response_model=EnrichedSkillMetadata,
+            messages=[
+                {"role": "system", "content": self._system_prompt()},
+                {"role": "user", "content": self._user_prompt(skill, known_concepts or [])},
+            ],
+            max_retries=self.max_retries,
+        )
+
+    def enrich_all(
+        self,
+        skills: list[AssembledSkill],
+        known_concepts: Optional[list[str]] = None,
+    ) -> list[dict[str, Any]]:
+        """Enrich a list of skills, producing combined dicts (raw + metadata).
+
+        Returns a list of dicts with shape:
+            {
+                "boundary": {...},
+                "steps": [...],
+                "metadata": {...} | None,   # None if enrichment failed
+                "enrichment_error": str | None,
+            }
+        """
+        results: list[dict[str, Any]] = []
+        for skill in skills:
+            entry: dict[str, Any] = {
+                "boundary": skill.boundary.to_dict(),
+                "steps": [s.to_dict() for s in skill.steps],
+                "metadata": None,
+                "enrichment_error": None,
+            }
+            try:
+                enriched = self.enrich(skill, known_concepts)
+                entry["metadata"] = enriched.model_dump()
+            except Exception as e:  # noqa: BLE001 - log and move on
+                logger.warning(
+                    "Enrichment failed for skill %r: %s",
+                    skill.boundary.anchor_header, e,
+                )
+                entry["enrichment_error"] = str(e)
+            results.append(entry)
+        return results

--- a/src/chunker/skills.py
+++ b/src/chunker/skills.py
@@ -230,14 +230,17 @@ def detect_skill_boundaries(chunks: list[Any]) -> list[SkillBoundary]:
 
             current_id = nxt.get("next_id")
 
-        # Minimum body signal: combined content must have >=2 numbered steps
-        # OR >=1 numbered step + >=1 code fence
+        # Minimum body signal: combined content must have >=2 step markers
+        # OR >=1 step marker + >=1 code fence. Fallback imperative parsing
+        # handles the "code fence only" case at phase B.
         combined = "\n\n".join(m.get("content", "") for m in collected)
         numbered_count = sum(
-            1 for _ in _STEP_MARKER_PATTERNS[0].finditer(combined)
+            len(p.findall(combined)) for p in _STEP_MARKER_PATTERNS
         )
         code_count = len(_CODE_FENCE.findall(combined))
-        if numbered_count < 2 and not (numbered_count >= 1 and code_count >= 1):
+        # Accept if: 2+ step markers, OR 1+ step marker + 1+ code fence,
+        # OR 2+ code fences (imperative fallback will find steps)
+        if numbered_count < 2 and not (numbered_count >= 1 and code_count >= 1) and code_count < 2:
             continue
 
         chunk_ids = [m["chunk_id"] for m in collected if m.get("chunk_id")]

--- a/src/chunker/skills.py
+++ b/src/chunker/skills.py
@@ -1,0 +1,460 @@
+"""Procedural skill extraction from textbook chunks.
+
+Detects skill boundaries in documents (multi-chunk "How to" sections) and
+re-assembles the fragmented chunks back into ordered, executable steps with
+code snippets and expected outputs.
+
+Two phases:
+
+- Phase A (detect): find anchor headers + walk sibling chunks to determine
+  skill boundaries. See `detect_skill_boundaries`.
+- Phase B (assemble): concatenate the raw markdown in a boundary and parse
+  it into RawStep objects. See `assemble_skill_steps`.
+
+Enrichment (LLM-based naming, prerequisites, verification) lives in
+`skill_synthesizer.py`. Storage orchestration (DB writes, edge linking)
+is added later.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Detection patterns
+# ---------------------------------------------------------------------------
+
+# Header patterns that strongly anchor a skill boundary
+_ANCHOR_HEADER_PATTERNS = [
+    re.compile(r"^(How\s+to|Steps\s+to|Tutorial|Walkthrough|Procedure|Exercise)\b", re.IGNORECASE),
+    # "To deploy an application:" — starts with "To " then an imperative verb + colon
+    re.compile(r"^To\s+[a-z]\w+.*:$", re.IGNORECASE),
+]
+
+# Markers that indicate a numbered/lettered step start inside content
+_STEP_MARKER_PATTERNS = [
+    re.compile(r"^\s*(\d+)\.\s+(.+)", re.MULTILINE),        # "1. Do thing"
+    re.compile(r"^\s*(\d+)\)\s+(.+)", re.MULTILINE),        # "1) Do thing"
+    re.compile(r"^\s*Step\s+(\d+)[:\.\s]\s*(.+)", re.MULTILINE | re.IGNORECASE),
+]
+
+# Expected output markers (Phase B)
+_OUTPUT_MARKERS = re.compile(
+    r"^\s*(?:Output|Returns|You\s+should\s+see|Expected\s+output|Result)[:\s]\s*(.*)$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Code fence regex (captures language + content)
+_CODE_FENCE = re.compile(
+    r"```(\w*)\s*\n(.*?)\n```",
+    re.DOTALL,
+)
+
+# Procedural body signals (used for density check)
+_PROCEDURAL_SIGNALS = [
+    re.compile(r"^\s*\d+[\.\)]\s+\S", re.MULTILINE),
+    re.compile(r"^\s*Step\s+\d+", re.MULTILINE | re.IGNORECASE),
+    re.compile(r"^```\w+", re.MULTILINE),
+    re.compile(r"\bFirst,\s", re.IGNORECASE),
+    re.compile(r"\bThen,\s", re.IGNORECASE),
+    re.compile(r"\bFinally,\s", re.IGNORECASE),
+]
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SkillBoundary:
+    """A contiguous range of chunks that together form a single skill."""
+
+    anchor_header: str                   # Text of the heading that anchored detection
+    anchor_header_level: int             # h1-h6 level of the anchor
+    chunk_ids: list[str] = field(default_factory=list)
+    start_chunk_id: str = ""
+    end_chunk_id: str = ""
+    document_id: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "anchor_header": self.anchor_header,
+            "anchor_header_level": self.anchor_header_level,
+            "chunk_ids": self.chunk_ids,
+            "start_chunk_id": self.start_chunk_id,
+            "end_chunk_id": self.end_chunk_id,
+            "document_id": self.document_id,
+        }
+
+
+@dataclass
+class RawStep:
+    """A parsed step from a skill's raw markdown."""
+
+    step_number: int
+    action: str                          # Narrative text describing the step
+    code_content: str = ""               # Verbatim code from a following fence
+    code_language: str = ""              # Language label from the fence
+    expected_output: str = ""            # "Output:"/"You should see:" snippet
+
+    def to_dict(self) -> dict:
+        return {
+            "step_number": self.step_number,
+            "action": self.action,
+            "code_content": self.code_content,
+            "code_language": self.code_language,
+            "expected_output": self.expected_output,
+        }
+
+
+@dataclass
+class AssembledSkill:
+    """A skill boundary + its parsed steps. Intermediate artifact (pre-LLM)."""
+
+    boundary: SkillBoundary
+    steps: list[RawStep] = field(default_factory=list)
+    raw_markdown: str = ""               # Source used for parsing (for debugging)
+
+    def to_dict(self) -> dict:
+        return {
+            "boundary": self.boundary.to_dict(),
+            "steps": [s.to_dict() for s in self.steps],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Phase A: Detection
+# ---------------------------------------------------------------------------
+
+
+def _is_anchor_header(header_text: Optional[str]) -> bool:
+    """Return True if `header_text` matches any anchor pattern."""
+    if not header_text:
+        return False
+    text = header_text.strip()
+    return any(p.match(text) for p in _ANCHOR_HEADER_PATTERNS)
+
+
+def _count_signals(content: str) -> int:
+    """Count how many procedural signals appear in a chunk's content."""
+    return sum(1 for p in _PROCEDURAL_SIGNALS if p.search(content))
+
+
+def _chunk_to_meta(chunk: Any) -> dict:
+    """Extract the relevant metadata dict from an EmbeddedChunk or dict.
+
+    Accepts both `EmbeddedChunk` objects (with `.chunk.metadata`) and plain
+    dicts (as produced by tests/fixtures).
+    """
+    if hasattr(chunk, "chunk"):
+        c = chunk.chunk
+        meta = dict(c.metadata or {})
+        meta.setdefault("chunk_id", c.id)
+        meta.setdefault("content", c.content)
+        meta.setdefault("prev_id", c.prev_id)
+        meta.setdefault("next_id", c.next_id)
+        meta.setdefault("level", c.level)
+        return meta
+    return dict(chunk)
+
+
+def detect_skill_boundaries(chunks: list[Any]) -> list[SkillBoundary]:
+    """Find skill boundaries in a document's chunks.
+
+    A boundary starts at a chunk whose `header_text` matches an anchor
+    pattern, and extends forward via `next_id` until a sibling or shallower
+    header ends it, or procedural signal density drops.
+
+    Args:
+        chunks: List of chunks for a single document. Can be EmbeddedChunk
+            objects or dicts with chunk_id/content/header_text/header_level
+            /prev_id/next_id fields.
+
+    Returns:
+        List of SkillBoundary objects, one per detected skill.
+    """
+    if not chunks:
+        return []
+
+    # Normalize and index by chunk_id for forward traversal
+    metas = [_chunk_to_meta(c) for c in chunks]
+    by_id = {m["chunk_id"]: m for m in metas if m.get("chunk_id")}
+    # Preserve input order for anchor scan
+    ordered = metas
+
+    boundaries: list[SkillBoundary] = []
+    consumed: set[str] = set()  # Chunks already part of a boundary
+
+    for anchor in ordered:
+        cid = anchor.get("chunk_id")
+        if not cid or cid in consumed:
+            continue
+        header_text = anchor.get("header_text")
+        anchor_level = anchor.get("header_level")
+        if not _is_anchor_header(header_text):
+            continue
+
+        # Walk forward collecting body chunks
+        collected: list[dict] = [anchor]
+        current_id = anchor.get("next_id")
+        weak_streak = 0
+        while current_id:
+            nxt = by_id.get(current_id)
+            if nxt is None:
+                break
+            # Stop at a sibling or shallower header
+            nxt_level = nxt.get("header_level")
+            nxt_text = nxt.get("header_text")
+            if (
+                nxt_text
+                and isinstance(anchor_level, int)
+                and isinstance(nxt_level, int)
+                and nxt_level <= anchor_level
+            ):
+                break
+
+            collected.append(nxt)
+
+            # Density check: stop if 3 consecutive chunks have no signals
+            if _count_signals(nxt.get("content", "")) == 0:
+                weak_streak += 1
+                if weak_streak >= 3:
+                    # Trim the trailing weak chunks — they don't belong
+                    collected = collected[: -weak_streak]
+                    break
+            else:
+                weak_streak = 0
+
+            current_id = nxt.get("next_id")
+
+        # Minimum body signal: combined content must have >=2 numbered steps
+        # OR >=1 numbered step + >=1 code fence
+        combined = "\n\n".join(m.get("content", "") for m in collected)
+        numbered_count = sum(
+            1 for _ in _STEP_MARKER_PATTERNS[0].finditer(combined)
+        )
+        code_count = len(_CODE_FENCE.findall(combined))
+        if numbered_count < 2 and not (numbered_count >= 1 and code_count >= 1):
+            continue
+
+        chunk_ids = [m["chunk_id"] for m in collected if m.get("chunk_id")]
+        boundary = SkillBoundary(
+            anchor_header=str(header_text).strip(),
+            anchor_header_level=int(anchor_level or 0),
+            chunk_ids=chunk_ids,
+            start_chunk_id=chunk_ids[0] if chunk_ids else "",
+            end_chunk_id=chunk_ids[-1] if chunk_ids else "",
+            document_id=anchor.get("document_id", ""),
+        )
+        boundaries.append(boundary)
+        consumed.update(chunk_ids)
+
+    return boundaries
+
+
+# ---------------------------------------------------------------------------
+# Phase B: Assembly
+# ---------------------------------------------------------------------------
+
+
+def _split_on_step_markers(text: str) -> list[tuple[int, str]]:
+    """Split text at numbered/stepped markers.
+
+    Returns a list of (step_number, segment_text) tuples. The first segment
+    before any marker is dropped (it's usually the anchor's intro paragraph).
+    """
+    # Find all marker positions
+    matches: list[tuple[int, int, str]] = []  # (start, number, following_text)
+    for pat in _STEP_MARKER_PATTERNS:
+        for m in pat.finditer(text):
+            try:
+                num = int(m.group(1))
+            except (ValueError, IndexError):
+                continue
+            matches.append((m.start(), num))
+    if not matches:
+        return []
+    matches.sort(key=lambda x: x[0])
+
+    segments: list[tuple[int, str]] = []
+    for i, (start, num) in enumerate(matches):
+        end = matches[i + 1][0] if i + 1 < len(matches) else len(text)
+        segment = text[start:end]
+        # Strip the marker itself from the segment's first line
+        segment = re.sub(r"^\s*(?:\d+[\.\)]|Step\s+\d+[:\.\s])\s*", "", segment, count=1, flags=re.IGNORECASE)
+        segments.append((num, segment))
+    return segments
+
+
+def _extract_code_and_output(segment: str) -> tuple[str, str, str, str]:
+    """Extract action text, code block, language, expected output from a segment.
+
+    Returns:
+        (action_text, code_content, code_language, expected_output)
+    """
+    # Find the first code fence
+    fence_match = _CODE_FENCE.search(segment)
+    code_content = ""
+    code_language = ""
+    if fence_match:
+        code_language = fence_match.group(1) or ""
+        code_content = fence_match.group(2).strip("\n")
+
+    # Action = text before the first code fence (or full text if no fence)
+    if fence_match:
+        action_text = segment[: fence_match.start()].strip()
+    else:
+        action_text = segment.strip()
+
+    # Look for expected output AFTER the first fence
+    expected_output = ""
+    if fence_match:
+        after_fence = segment[fence_match.end():]
+        # Option 1: explicit "Output:" marker
+        out_match = _OUTPUT_MARKERS.search(after_fence)
+        if out_match:
+            # Capture the marker's own line + any immediately following
+            # fenced output block
+            remaining = after_fence[out_match.start():]
+            output_fence = _CODE_FENCE.search(remaining)
+            if output_fence and output_fence.start() < 200:
+                expected_output = output_fence.group(2).strip("\n")
+            else:
+                # Just the rest of the marker line
+                expected_output = out_match.group(1).strip()
+        else:
+            # Option 2: second fence labeled console/output immediately after
+            second_fence = _CODE_FENCE.search(after_fence)
+            if second_fence and second_fence.start() < 150:
+                lang = (second_fence.group(1) or "").lower()
+                if lang in {"console", "output", "stdout", "text"}:
+                    expected_output = second_fence.group(2).strip("\n")
+
+    # Collapse whitespace in action text
+    action_text = re.sub(r"\s+\n", "\n", action_text).strip()
+    return action_text, code_content, code_language, expected_output
+
+
+def assemble_skill_steps(
+    boundary: SkillBoundary,
+    chunks: list[Any],
+) -> AssembledSkill:
+    """Parse a skill boundary's chunks back into ordered steps.
+
+    Concatenates chunk contents in the boundary's `chunk_ids` order, then
+    runs a deterministic parser to extract numbered steps with code blocks
+    and expected outputs.
+
+    Args:
+        boundary: The SkillBoundary to assemble.
+        chunks: All chunks for the document (used to look up content).
+
+    Returns:
+        AssembledSkill with boundary + parsed RawStep list.
+    """
+    # Build id -> content map
+    metas = [_chunk_to_meta(c) for c in chunks]
+    by_id = {m["chunk_id"]: m for m in metas if m.get("chunk_id")}
+
+    parts: list[str] = []
+    for cid in boundary.chunk_ids:
+        m = by_id.get(cid)
+        if m and m.get("content"):
+            parts.append(m["content"])
+    raw = "\n\n".join(parts)
+
+    segments = _split_on_step_markers(raw)
+    steps: list[RawStep] = []
+
+    if segments:
+        for num, segment in segments:
+            action, code, lang, output = _extract_code_and_output(segment)
+            if not action and not code:
+                continue
+            steps.append(RawStep(
+                step_number=num,
+                action=action,
+                code_content=code,
+                code_language=lang,
+                expected_output=output,
+            ))
+        # Renumber sequentially (in case the source skipped numbers)
+        steps = [
+            RawStep(
+                step_number=i + 1,
+                action=s.action,
+                code_content=s.code_content,
+                code_language=s.code_language,
+                expected_output=s.expected_output,
+            )
+            for i, s in enumerate(steps)
+        ]
+    else:
+        # Fallback: no explicit step markers. Treat each imperative
+        # paragraph as a step.
+        steps = _fallback_parse_imperatives(raw)
+
+    return AssembledSkill(boundary=boundary, steps=steps, raw_markdown=raw)
+
+
+_IMPERATIVE_VERBS = (
+    "run", "create", "install", "configure", "deploy", "apply", "build",
+    "open", "click", "navigate", "add", "remove", "update", "start", "stop",
+    "write", "save", "edit", "restart", "check", "verify", "test", "set",
+    "export", "import", "generate", "copy", "paste", "type", "enter",
+)
+
+
+def _fallback_parse_imperatives(raw: str) -> list[RawStep]:
+    """Split on paragraphs; keep ones starting with an imperative verb."""
+    paragraphs = re.split(r"\n\s*\n", raw)
+    steps: list[RawStep] = []
+    pending_action = ""
+
+    for para in paragraphs:
+        stripped = para.strip()
+        if not stripped:
+            continue
+        # Check if paragraph is a code fence
+        fence_match = _CODE_FENCE.match(stripped)
+        if fence_match and pending_action:
+            # Attach to the most recent step
+            steps[-1] = RawStep(
+                step_number=steps[-1].step_number,
+                action=steps[-1].action,
+                code_content=fence_match.group(2).strip("\n"),
+                code_language=fence_match.group(1) or "",
+                expected_output=steps[-1].expected_output,
+            )
+            continue
+
+        first_word = stripped.split()[0].lower().rstrip(",.:")
+        if first_word in _IMPERATIVE_VERBS:
+            steps.append(RawStep(
+                step_number=len(steps) + 1,
+                action=stripped,
+            ))
+            pending_action = stripped
+
+    return steps
+
+
+# ---------------------------------------------------------------------------
+# Convenience
+# ---------------------------------------------------------------------------
+
+
+def extract_skills(chunks: list[Any]) -> list[AssembledSkill]:
+    """Run detection + assembly in one call.
+
+    Args:
+        chunks: All chunks for a single document.
+
+    Returns:
+        List of AssembledSkill objects (one per detected boundary).
+    """
+    boundaries = detect_skill_boundaries(chunks)
+    return [assemble_skill_steps(b, chunks) for b in boundaries]

--- a/src/cli/commands/skills.py
+++ b/src/cli/commands/skills.py
@@ -1,0 +1,228 @@
+"""CLI commands for extracting procedural skills from textbook documents."""
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from ..config import CLIConfig
+from ..output import console, print_error, print_json, print_success, print_warning
+from ..utils import get_store
+
+logger = logging.getLogger(__name__)
+
+app = typer.Typer(help="Extract procedural skills from textbook documents")
+
+SKILLS_DIR = Path.home() / ".kidkazz" / "skills"
+
+
+def _safe_filename(doc_id: str) -> str:
+    """Sanitize doc_id for safe use in filenames (prevent path traversal)."""
+    return re.sub(r"[^\w\-]", "_", doc_id)[:100]
+
+
+def _embedded_chunk_to_dict(ec) -> dict:
+    """Convert an EmbeddedChunk into the dict shape skills.py expects."""
+    c = ec.chunk if hasattr(ec, "chunk") else ec
+    meta = c.metadata or {}
+    return {
+        "chunk_id": c.id,
+        "content": c.content,
+        "level": c.level,
+        "prev_id": c.prev_id,
+        "next_id": c.next_id,
+        "header_text": meta.get("header_text"),
+        "header_level": meta.get("header_level"),
+        "semantic_type": meta.get("semantic_type"),
+        "document_id": meta.get("document_id", ""),
+    }
+
+
+@app.command("extract")
+def extract(
+    doc_id: str = typer.Argument(..., help="Document ID to extract skills from"),
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help="Output JSON path (default: ~/.kidkazz/skills/<doc_id>.json)",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Print the JSON payload to stdout instead of saving",
+    ),
+    include_raw: bool = typer.Option(
+        False,
+        "--include-raw",
+        help="Include raw concatenated markdown per skill (debugging)",
+    ),
+) -> None:
+    """Detect and assemble procedural skills from a document (no LLM, no DB).
+
+    Walks the document's chunks to find "How to" / "Steps to" / "Tutorial"
+    sections, then re-parses the raw markdown to reconstruct step→code→output
+    structure. Outputs JSON — no database writes, no LLM calls. Use this to
+    preview and tune the parser before investing in enrichment/storage.
+    """
+    from src.chunker.skills import extract_skills
+
+    config = CLIConfig.load()
+    store = get_store(config)
+
+    # Fetch all chunks for the document
+    chunks = store.get_document_chunks(doc_id)
+    if not chunks:
+        print_error(f"No chunks found for document '{doc_id}'")
+        raise typer.Exit(1)
+
+    chunk_dicts = [_embedded_chunk_to_dict(ec) for ec in chunks]
+
+    # Sort by sequence_position if available (safer than trusting prev/next
+    # alone, since prev/next can be None for chunks not in a reading chain)
+    def _seq(d):
+        meta = d.get("metadata") or {}
+        return meta.get("sequence_position", 0)
+    # The metadata dict is inside chunk.metadata which we already flattened;
+    # Chunk has section_path/level/etc. but not sequence_position directly —
+    # rely on the input order from get_document_chunks for now.
+
+    skills = extract_skills(chunk_dicts)
+
+    payload = {
+        "doc_id": doc_id,
+        "skill_count": len(skills),
+        "skills": [],
+    }
+    for s in skills:
+        skill_dict = s.to_dict()
+        if include_raw:
+            skill_dict["raw_markdown"] = s.raw_markdown
+        payload["skills"].append(skill_dict)
+
+    # Output
+    if json_output:
+        print_json(payload)
+        return
+
+    output_path = output or (SKILLS_DIR / f"{_safe_filename(doc_id)}.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
+
+    # Summary to stdout
+    _print_summary(payload, output_path)
+
+
+@app.command("show")
+def show(
+    doc_id: str = typer.Argument(..., help="Document ID"),
+    json_output: bool = typer.Option(False, "--json", help="Print raw JSON"),
+) -> None:
+    """Show previously extracted skills for a document."""
+    path = SKILLS_DIR / f"{_safe_filename(doc_id)}.json"
+    if not path.exists():
+        print_error(f"No skill extraction found for '{doc_id}'")
+        print_warning(f"Run: kidkazz skills extract {doc_id}")
+        raise typer.Exit(1)
+
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print_error(f"Corrupt skills file {path}: {e}")
+        raise typer.Exit(1)
+
+    if json_output:
+        print_json(data)
+        return
+
+    _print_summary(data, path)
+
+
+@app.command("list")
+def list_extracted(
+    json_output: bool = typer.Option(False, "--json", help="Print raw JSON"),
+) -> None:
+    """List documents that have extracted skills on disk."""
+    if not SKILLS_DIR.exists():
+        print_warning("No extracted skills found.")
+        return
+
+    entries = []
+    for path in sorted(SKILLS_DIR.glob("*.json")):
+        try:
+            data = json.loads(path.read_text())
+            entries.append({
+                "doc_id": data.get("doc_id", path.stem),
+                "skill_count": data.get("skill_count", 0),
+                "file": str(path),
+            })
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            continue
+
+    if json_output:
+        print_json(entries)
+        return
+
+    if not entries:
+        print_warning("No extracted skills found.")
+        return
+
+    from rich.table import Table
+
+    table = Table(title="Extracted Skills", show_header=True, header_style="bold cyan")
+    table.add_column("Document ID", style="cyan")
+    table.add_column("Skills", justify="right")
+    table.add_column("File", style="dim")
+    for e in entries:
+        table.add_row(e["doc_id"], str(e["skill_count"]), e["file"])
+    console.print(table)
+
+
+def _print_summary(payload: dict, output_path: Path) -> None:
+    """Print a human-readable summary of extracted skills."""
+    from rich.panel import Panel
+    from rich.table import Table
+
+    doc_id = payload.get("doc_id", "?")
+    skills = payload.get("skills", [])
+
+    console.print()
+    console.print(Panel(
+        f"[bold]{doc_id}[/bold] — {len(skills)} skill(s) extracted",
+        title="Skill Extraction",
+        border_style="green",
+    ))
+
+    if not skills:
+        console.print("[yellow]No skills detected in this document.[/yellow]")
+        console.print("[dim]Tip: skills require a 'How to' / 'Steps to' / "
+                      "'Tutorial' header plus numbered steps or code fences.[/dim]")
+        console.print()
+        print_success(f"Saved to: {output_path}")
+        return
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("#", style="dim", width=3)
+    table.add_column("Anchor Header", style="cyan")
+    table.add_column("Steps", justify="right")
+    table.add_column("Chunks", justify="right")
+    table.add_column("Has Code", justify="center")
+
+    for i, skill in enumerate(skills, 1):
+        boundary = skill.get("boundary", {})
+        steps = skill.get("steps", [])
+        has_code = any(s.get("code_content") for s in steps)
+        table.add_row(
+            str(i),
+            boundary.get("anchor_header", "?"),
+            str(len(steps)),
+            str(len(boundary.get("chunk_ids", []))),
+            "✓" if has_code else "",
+        )
+
+    console.print(table)
+    console.print()
+    print_success(f"Saved to: {output_path}")

--- a/src/cli/commands/skills.py
+++ b/src/cli/commands/skills.py
@@ -134,6 +134,208 @@ def extract(
     _print_summary(payload, output_path)
 
 
+def _slugify(text: str) -> str:
+    """URL-friendly slug for skill_id."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[\s_-]+", "-", text)
+    return text.strip("-")[:80] or "unnamed-skill"
+
+
+@app.command("generate")
+def generate(
+    doc_id: str = typer.Argument(..., help="Document ID to generate skills for"),
+    provider: str = typer.Option(
+        "openai/gpt-4o-mini",
+        "--provider",
+        "-p",
+        help="LLM provider for enrichment",
+    ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        help="Extraction profile (auto-detected from document book_type if unset)",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Extract + enrich but don't persist to DB",
+    ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Print summary as JSON",
+    ),
+) -> None:
+    """End-to-end skill synthesis: extract + enrich + persist to Helix-DB.
+
+    Walks the document's chunks to find procedural sections, re-parses
+    them into ordered steps, enriches via LLM, and stores as Skill +
+    SkillStep nodes linked to the concept graph.
+    """
+    import time
+
+    from src.chunker.skills import extract_skills
+
+    config = CLIConfig.load()
+    store = get_store(config)
+
+    chunks = store.get_document_chunks(doc_id)
+    if not chunks:
+        print_error(f"No chunks found for document '{doc_id}'")
+        raise typer.Exit(1)
+
+    chunk_dicts = [_embedded_chunk_to_dict(ec) for ec in chunks]
+    raw_skills = extract_skills(chunk_dicts)
+
+    if not raw_skills:
+        print_warning(f"No procedural skills detected in '{doc_id}'.")
+        print_warning("Skills require a 'How to' / 'Steps to' header plus numbered steps or code fences.")
+        return
+
+    logger.info("Detected %d skill boundaries, starting enrichment...", len(raw_skills))
+
+    # Enrich via LLM
+    try:
+        from src.chunker.skill_synthesizer import SkillSynthesizer
+    except ImportError as e:
+        print_error(f"Missing dependency: {e}")
+        print_warning("Install with: pip install 'kidkazz[concepts]'")
+        raise typer.Exit(1)
+
+    profile_name = _resolve_profile(profile, doc_id, store, config)
+    extraction_profile = None
+    if profile_name and profile_name != "general":
+        try:
+            from src.chunker.profiles import get_profile
+            extraction_profile = get_profile(profile_name)
+        except ValueError:
+            logger.warning("Unknown profile '%s'", profile_name)
+
+    known_concepts: list[str] = []
+    try:
+        all_concepts = store.list_concepts(doc_id=doc_id)
+        known_concepts = [c.get("name", "") for c in all_concepts if c.get("name")]
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not fetch known concepts: %s", e)
+
+    synthesizer = SkillSynthesizer(provider=provider, profile=extraction_profile)
+    enriched_entries = synthesizer.enrich_all(raw_skills, known_concepts=known_concepts)
+
+    # Build skill payloads and persist
+    stored_count = 0
+    skipped_count = 0
+
+    for entry in enriched_entries:
+        if entry.get("enrichment_error") or not entry.get("metadata"):
+            skipped_count += 1
+            continue
+
+        boundary = entry["boundary"]
+        steps_list = entry["steps"]
+        meta = entry["metadata"]
+
+        skill_id = _slugify(meta["name"])
+        has_code = 1 if any(s.get("code_content") for s in steps_list) else 0
+
+        skill_props = {
+            "skill_id": skill_id,
+            "name": meta["name"],
+            "goal": meta.get("goal", ""),
+            "domain": profile_name or "general",
+            "difficulty": meta.get("difficulty", "intermediate"),
+            "source_document_id": doc_id,
+            "anchor_header": boundary.get("anchor_header", ""),
+            "source_chunk_ids": json.dumps(boundary.get("chunk_ids", [])),
+            "success_criteria": meta.get("success_criteria", ""),
+            "common_failures": json.dumps(meta.get("common_failures", [])),
+            "step_count": len(steps_list),
+            "has_code": has_code,
+            "created_at": int(time.time()),
+        }
+
+        step_payloads = [
+            {
+                "step_id": f"{skill_id}_step_{i + 1}",
+                "skill_id": skill_id,
+                "step_number": i + 1,
+                "action": s.get("action", ""),
+                "code_content": s.get("code_content", ""),
+                "code_language": s.get("code_language", ""),
+                "expected_output": s.get("expected_output", ""),
+                "is_optional": 0,
+            }
+            for i, s in enumerate(steps_list)
+        ]
+
+        if dry_run:
+            stored_count += 1
+            continue
+
+        try:
+            skill_internal_id = store.store_skill(skill_props, step_payloads)
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to store skill %r: %s", meta["name"], e)
+            skipped_count += 1
+            continue
+
+        if not skill_internal_id:
+            skipped_count += 1
+            continue
+
+        # Link prerequisite concepts by name
+        for concept_name in meta.get("prerequisite_concepts", []):
+            _link_concept(store, skill_internal_id, concept_name, "requires")
+        for concept_name in meta.get("produces_concepts", []):
+            _link_concept(store, skill_internal_id, concept_name, "produces")
+
+        stored_count += 1
+
+    summary = {
+        "doc_id": doc_id,
+        "detected": len(raw_skills),
+        "enriched": sum(1 for e in enriched_entries if e.get("metadata")),
+        "stored": stored_count,
+        "skipped": skipped_count,
+        "dry_run": dry_run,
+    }
+    if json_output:
+        print_json(summary)
+    else:
+        console.print()
+        from rich.table import Table
+        t = Table(title=f"Skill Generation: {doc_id}", show_header=False)
+        t.add_column("Metric")
+        t.add_column("Value", justify="right")
+        t.add_row("Detected boundaries", str(summary["detected"]))
+        t.add_row("Successfully enriched", str(summary["enriched"]))
+        t.add_row("Stored" if not dry_run else "Would store (dry-run)", str(summary["stored"]))
+        t.add_row("Skipped", str(summary["skipped"]))
+        console.print(t)
+        if not dry_run and stored_count > 0:
+            print_success(f"Stored {stored_count} skill(s) for '{doc_id}'")
+
+
+def _link_concept(store, skill_internal_id: str, concept_name: str, relation: str) -> None:
+    """Resolve a concept name to its internal ID and link it to a skill."""
+    if not concept_name:
+        return
+    try:
+        concept = store.get_concept_by_name(concept_name)
+    except Exception:  # noqa: BLE001
+        concept = None
+    if not concept:
+        logger.debug("Concept %r not found in KB; skipping %s link", concept_name, relation)
+        return
+    concept_internal_id = concept.get("id")
+    if not concept_internal_id:
+        return
+    if relation == "requires":
+        store.link_skill_requires_concept(skill_internal_id, concept_internal_id)
+    elif relation == "produces":
+        store.link_skill_produces_concept(skill_internal_id, concept_internal_id)
+
+
 @app.command("show")
 def show(
     doc_id: str = typer.Argument(..., help="Document ID"),

--- a/src/cli/commands/skills.py
+++ b/src/cli/commands/skills.py
@@ -222,9 +222,13 @@ def generate(
     synthesizer = SkillSynthesizer(provider=provider, profile=extraction_profile)
     enriched_entries = synthesizer.enrich_all(raw_skills, known_concepts=known_concepts)
 
-    # Build skill payloads and persist
+    # Build skill payloads and persist. Track skills by name so we can link
+    # prerequisite_skills (LLM emits names) in a second pass.
     stored_count = 0
     skipped_count = 0
+    name_to_internal_id: dict[str, str] = {}
+    pending_skill_prereqs: list[tuple[str, list[str]]] = []  # (internal_id, prereq_names)
+    doc_scope = _slugify(doc_id)[:40]  # short, safe prefix
 
     for entry in enriched_entries:
         if entry.get("enrichment_error") or not entry.get("metadata"):
@@ -235,7 +239,9 @@ def generate(
         steps_list = entry["steps"]
         meta = entry["metadata"]
 
-        skill_id = _slugify(meta["name"])
+        # Document-scoped skill_id prevents cross-doc collisions
+        name_slug = _slugify(meta["name"])
+        skill_id = f"{doc_scope}__{name_slug}" if doc_scope else name_slug
         has_code = 1 if any(s.get("code_content") for s in steps_list) else 0
 
         skill_props = {
@@ -256,7 +262,7 @@ def generate(
 
         step_payloads = [
             {
-                "step_id": f"{skill_id}_step_{i + 1}",
+                "step_id": f"{skill_id}__step_{i + 1}",
                 "skill_id": skill_id,
                 "step_number": i + 1,
                 "action": s.get("action", ""),
@@ -283,13 +289,41 @@ def generate(
             skipped_count += 1
             continue
 
-        # Link prerequisite concepts by name
+        # Link prerequisite/produced concepts by name
         for concept_name in meta.get("prerequisite_concepts", []):
             _link_concept(store, skill_internal_id, concept_name, "requires")
         for concept_name in meta.get("produces_concepts", []):
             _link_concept(store, skill_internal_id, concept_name, "produces")
 
+        # Defer skill-to-skill prereqs until all skills exist (forward refs)
+        name_to_internal_id[meta["name"]] = skill_internal_id
+        prereq_skill_names = meta.get("prerequisite_skills") or []
+        if prereq_skill_names:
+            pending_skill_prereqs.append((skill_internal_id, prereq_skill_names))
+
         stored_count += 1
+
+    # Second pass: resolve skill-to-skill prerequisites now that all skills
+    # from this document are stored. Missing targets are logged and skipped.
+    if not dry_run:
+        for skill_iid, prereq_names in pending_skill_prereqs:
+            for prereq_name in prereq_names:
+                target_iid = name_to_internal_id.get(prereq_name)
+                if not target_iid:
+                    # Try looking up a pre-existing skill by name
+                    try:
+                        existing = store.get_skill_by_name(prereq_name)
+                    except Exception:  # noqa: BLE001
+                        existing = None
+                    if existing:
+                        target_iid = existing.get("id") or existing.get("skill_id")
+                if not target_iid:
+                    logger.debug("Prerequisite skill %r not found; skipping link", prereq_name)
+                    continue
+                try:
+                    store.link_skill_requires_skill(skill_iid, target_iid)
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("Failed to link skill prereq %r: %s", prereq_name, e)
 
     summary = {
         "doc_id": doc_id,

--- a/src/cli/commands/skills.py
+++ b/src/cli/commands/skills.py
@@ -10,7 +10,7 @@ import typer
 
 from ..config import CLIConfig
 from ..output import console, print_error, print_json, print_success, print_warning
-from ..utils import get_store
+from ..utils import get_embedder, get_store
 
 logger = logging.getLogger(__name__)
 
@@ -229,6 +229,14 @@ def generate(
     name_to_internal_id: dict[str, str] = {}
     pending_skill_prereqs: list[tuple[str, list[str]]] = []  # (internal_id, prereq_names)
     doc_scope = _slugify(doc_id)[:40]  # short, safe prefix
+    used_skill_ids: dict[str, int] = {}  # collision counter within this batch
+
+    # Embedder for SkillVector (reuses ingestion embedder so search dims match)
+    try:
+        embedder = get_embedder(config)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not initialize embedder: %s", e)
+        embedder = None
 
     for entry in enriched_entries:
         if entry.get("enrichment_error") or not entry.get("metadata"):
@@ -239,9 +247,13 @@ def generate(
         steps_list = entry["steps"]
         meta = entry["metadata"]
 
-        # Document-scoped skill_id prevents cross-doc collisions
+        # Document-scoped skill_id prevents cross-doc collisions; counter
+        # suffix prevents same-name collisions within the same batch.
         name_slug = _slugify(meta["name"])
-        skill_id = f"{doc_scope}__{name_slug}" if doc_scope else name_slug
+        base_skill_id = f"{doc_scope}__{name_slug}" if doc_scope else name_slug
+        seen = used_skill_ids.get(base_skill_id, 0)
+        skill_id = base_skill_id if seen == 0 else f"{base_skill_id}_{seen + 1}"
+        used_skill_ids[base_skill_id] = seen + 1
         has_code = 1 if any(s.get("code_content") for s in steps_list) else 0
 
         skill_props = {
@@ -278,8 +290,30 @@ def generate(
             stored_count += 1
             continue
 
+        # Embed the skill's identity (name + goal + success criteria) so
+        # search_skills() can find it via vector similarity.
+        embedding = None
+        embedding_model = "unknown"
+        if embedder is not None:
+            embed_text = " ".join(filter(None, [
+                meta["name"],
+                meta.get("goal", ""),
+                meta.get("success_criteria", ""),
+            ])).strip()
+            if embed_text:
+                try:
+                    embedding = embedder.embed_query(embed_text)
+                    embedding_model = getattr(embedder, "model_name", "unknown")
+                except Exception as e:  # noqa: BLE001
+                    logger.warning("Failed to embed skill %r: %s", meta["name"], e)
+
         try:
-            skill_internal_id = store.store_skill(skill_props, step_payloads)
+            skill_internal_id = store.store_skill(
+                skill_props,
+                step_payloads,
+                embedding=embedding,
+                embedding_model=embedding_model,
+            )
         except Exception as e:  # noqa: BLE001
             logger.error("Failed to store skill %r: %s", meta["name"], e)
             skipped_count += 1

--- a/src/cli/commands/skills.py
+++ b/src/cli/commands/skills.py
@@ -60,13 +60,31 @@ def extract(
         "--include-raw",
         help="Include raw concatenated markdown per skill (debugging)",
     ),
+    enrich: bool = typer.Option(
+        False,
+        "--enrich",
+        help="Call LLM to add name, goal, prerequisites, and common failures",
+    ),
+    provider: str = typer.Option(
+        "openai/gpt-4o-mini",
+        "--provider",
+        "-p",
+        help="LLM provider for enrichment (requires --enrich)",
+    ),
+    profile: Optional[str] = typer.Option(
+        None,
+        "--profile",
+        help="Extraction profile (auto-detected from document if unset)",
+    ),
 ) -> None:
-    """Detect and assemble procedural skills from a document (no LLM, no DB).
+    """Detect and assemble procedural skills from a document.
 
     Walks the document's chunks to find "How to" / "Steps to" / "Tutorial"
     sections, then re-parses the raw markdown to reconstruct step→code→output
-    structure. Outputs JSON — no database writes, no LLM calls. Use this to
-    preview and tune the parser before investing in enrichment/storage.
+    structure. Outputs JSON — no database writes.
+
+    With --enrich, adds a single LLM call per skill to generate a canonical
+    name, goal, prerequisites, and common failure modes.
     """
     from src.chunker.skills import extract_skills
 
@@ -80,28 +98,28 @@ def extract(
         raise typer.Exit(1)
 
     chunk_dicts = [_embedded_chunk_to_dict(ec) for ec in chunks]
-
-    # Sort by sequence_position if available (safer than trusting prev/next
-    # alone, since prev/next can be None for chunks not in a reading chain)
-    def _seq(d):
-        meta = d.get("metadata") or {}
-        return meta.get("sequence_position", 0)
-    # The metadata dict is inside chunk.metadata which we already flattened;
-    # Chunk has section_path/level/etc. but not sequence_position directly —
-    # rely on the input order from get_document_chunks for now.
-
     skills = extract_skills(chunk_dicts)
 
-    payload = {
+    payload: dict = {
         "doc_id": doc_id,
         "skill_count": len(skills),
+        "enriched": False,
         "skills": [],
     }
-    for s in skills:
-        skill_dict = s.to_dict()
-        if include_raw:
-            skill_dict["raw_markdown"] = s.raw_markdown
-        payload["skills"].append(skill_dict)
+
+    if enrich and skills:
+        _enrich_skills(payload, skills, store, doc_id, provider, profile, config)
+    else:
+        for s in skills:
+            skill_dict = s.to_dict()
+            if include_raw:
+                skill_dict["raw_markdown"] = s.raw_markdown
+            payload["skills"].append(skill_dict)
+
+    if include_raw and enrich:
+        # Enrichment path overwrote skills; re-attach raw markdown
+        for skill_entry, source in zip(payload["skills"], skills, strict=False):
+            skill_entry["raw_markdown"] = source.raw_markdown
 
     # Output
     if json_output:
@@ -181,6 +199,54 @@ def list_extracted(
     console.print(table)
 
 
+def _resolve_profile(profile_arg: Optional[str], doc_id: str, store, config) -> Optional[str]:
+    """Resolve profile name: flag > document book_type > config default."""
+    if profile_arg:
+        return profile_arg
+    docs = store.list_documents()
+    doc = next((d for d in docs if d.get("doc_id") == doc_id), None)
+    stored = (doc or {}).get("book_type", "")
+    return stored or config.extraction_profile
+
+
+def _enrich_skills(payload: dict, skills: list, store, doc_id: str,
+                   provider: str, profile_arg: Optional[str], config) -> None:
+    """Run LLM enrichment on the extracted skills, mutating `payload` in place."""
+    try:
+        from src.chunker.skill_synthesizer import SkillSynthesizer
+    except ImportError as e:
+        print_error(f"Missing dependency for --enrich: {e}")
+        print_warning("Install with: pip install 'kidkazz[concepts]'")
+        raise typer.Exit(1)
+
+    # Resolve profile for domain-specific prompt
+    profile_name = _resolve_profile(profile_arg, doc_id, store, config)
+    extraction_profile = None
+    if profile_name and profile_name != "general":
+        try:
+            from src.chunker.profiles import get_profile
+            extraction_profile = get_profile(profile_name)
+            logger.info("Using extraction profile: %s", profile_name)
+        except ValueError:
+            logger.warning("Unknown profile '%s', continuing without profile hints", profile_name)
+
+    # Fetch known concepts once so the LLM can map prereqs to existing entries
+    known_concepts: list[str] = []
+    try:
+        all_concepts = store.list_concepts(doc_id=doc_id)
+        known_concepts = [c.get("name", "") for c in all_concepts if c.get("name")]
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not fetch known concepts: %s", e)
+
+    synthesizer = SkillSynthesizer(provider=provider, profile=extraction_profile)
+    enriched_entries = synthesizer.enrich_all(skills, known_concepts=known_concepts)
+
+    payload["enriched"] = True
+    payload["provider"] = provider
+    payload["profile"] = profile_name
+    payload["skills"] = enriched_entries
+
+
 def _print_summary(payload: dict, output_path: Path) -> None:
     """Print a human-readable summary of extracted skills."""
     from rich.panel import Panel
@@ -204,9 +270,15 @@ def _print_summary(payload: dict, output_path: Path) -> None:
         print_success(f"Saved to: {output_path}")
         return
 
+    enriched = payload.get("enriched", False)
+
     table = Table(show_header=True, header_style="bold")
     table.add_column("#", style="dim", width=3)
-    table.add_column("Anchor Header", style="cyan")
+    if enriched:
+        table.add_column("Name", style="cyan")
+        table.add_column("Difficulty", style="yellow")
+    else:
+        table.add_column("Anchor Header", style="cyan")
     table.add_column("Steps", justify="right")
     table.add_column("Chunks", justify="right")
     table.add_column("Has Code", justify="center")
@@ -214,15 +286,46 @@ def _print_summary(payload: dict, output_path: Path) -> None:
     for i, skill in enumerate(skills, 1):
         boundary = skill.get("boundary", {})
         steps = skill.get("steps", [])
+        meta = skill.get("metadata") or {}
         has_code = any(s.get("code_content") for s in steps)
-        table.add_row(
-            str(i),
-            boundary.get("anchor_header", "?"),
-            str(len(steps)),
-            str(len(boundary.get("chunk_ids", []))),
-            "✓" if has_code else "",
-        )
+        if enriched:
+            table.add_row(
+                str(i),
+                meta.get("name") or boundary.get("anchor_header", "?"),
+                meta.get("difficulty", "-"),
+                str(len(steps)),
+                str(len(boundary.get("chunk_ids", []))),
+                "✓" if has_code else "",
+            )
+        else:
+            table.add_row(
+                str(i),
+                boundary.get("anchor_header", "?"),
+                str(len(steps)),
+                str(len(boundary.get("chunk_ids", []))),
+                "✓" if has_code else "",
+            )
 
     console.print(table)
+
+    if enriched:
+        # Print per-skill enriched details
+        for i, skill in enumerate(skills, 1):
+            meta = skill.get("metadata")
+            if not meta:
+                continue
+            console.print()
+            console.print(f"[bold cyan]{i}. {meta.get('name', '?')}[/bold cyan]")
+            if meta.get("goal"):
+                console.print(f"  [dim]Goal:[/dim] {meta['goal']}")
+            if meta.get("success_criteria"):
+                console.print(f"  [dim]Success:[/dim] {meta['success_criteria']}")
+            prereq = meta.get("prerequisite_concepts", [])
+            if prereq:
+                console.print(f"  [dim]Prerequisites:[/dim] {', '.join(prereq[:5])}")
+            failures = meta.get("common_failures", [])
+            if failures:
+                console.print(f"  [dim]Common failures:[/dim] {len(failures)}")
+
     console.print()
     print_success(f"Saved to: {output_path}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import typer
 
-from .commands import concepts, config_cmd, db, distill, docs, inbox, ingest, search, summarize
+from .commands import concepts, config_cmd, db, distill, docs, inbox, ingest, search, skills, summarize
 
 # Create main app
 app = typer.Typer(
@@ -27,6 +27,7 @@ app.add_typer(inbox.app, name="inbox", help="Manage PDF inbox")
 app.add_typer(concepts.app, name="concepts", help="Concept extraction and management")
 app.add_typer(summarize.app, name="summarize", help="Document summarization")
 app.add_typer(distill.app, name="distill", help="Distill textbooks into agent configs")
+app.add_typer(skills.app, name="skills", help="Extract procedural skills from documents")
 
 
 @app.callback()

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -973,13 +973,9 @@ def register_tools(mcp: Any, state: ServerState) -> None:
         if not skill:
             return {"error": f"Skill '{skill_id}' not found"}
 
-        internal_id = skill.get("id")
-        if not internal_id:
-            return {
-                "prerequisite_concepts": [],
-                "prerequisite_skills": [],
-                "produces_concepts": [],
-            }
+        # HelixChunkStore returns node with 'id' (internal Helix ID);
+        # MockChunkStore stores by skill_id directly. Fall back so both work.
+        internal_id = skill.get("id") or skill_id
 
         return {
             "skill_id": skill_id,

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -831,3 +831,195 @@ def register_tools(mcp: Any, state: ServerState) -> None:
 
         logger.info(f"list_summarized_documents: found {len(docs)} documents")
         return docs
+
+    # ========================================================================
+    # SKILL TOOLS (procedural how-to knowledge)
+    # ========================================================================
+
+    @mcp.tool()
+    def get_skill(skill_id: str) -> dict[str, Any]:
+        """Get a procedural skill by its ID, including all ordered steps.
+
+        A skill is a named, executable procedure extracted from a textbook
+        (e.g., "Deploy app to Kubernetes"). Steps include action text, code
+        snippets, and expected outputs.
+
+        Args:
+            skill_id: Slugified skill identifier (e.g., "deploy-app-to-kubernetes")
+
+        Returns:
+            Dict with skill metadata and an ordered 'steps' list. Returns
+            {"error": ...} if not found.
+        """
+        logger.info(f"get_skill: skill_id={skill_id}")
+
+        skill = state.store.get_skill(skill_id)
+        if not skill:
+            return {"error": f"Skill '{skill_id}' not found"}
+
+        steps = state.store.get_skill_steps(skill_id)
+        return _format_skill_with_steps(skill, steps)
+
+    @mcp.tool()
+    def get_skill_by_name(name: str) -> dict[str, Any]:
+        """Get a skill by its display name.
+
+        Useful when you know the name but not the slug.
+
+        Args:
+            name: Display name (e.g., "Deploy app to Kubernetes")
+
+        Returns:
+            Dict with skill metadata and ordered steps, or {"error": ...}.
+        """
+        logger.info(f"get_skill_by_name: name={name!r}")
+
+        skill = state.store.get_skill_by_name(name)
+        if not skill:
+            return {"error": f"Skill with name {name!r} not found"}
+
+        skill_id = skill.get("skill_id", "")
+        steps = state.store.get_skill_steps(skill_id) if skill_id else []
+        return _format_skill_with_steps(skill, steps)
+
+    @mcp.tool()
+    def list_skills(
+        doc_id: Optional[str] = None,
+        domain: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """List available skills, optionally filtered by document or domain.
+
+        Args:
+            doc_id: Filter to skills extracted from a specific document
+            domain: Filter by domain (programming, erp, stem, agriculture, veterinary, general)
+
+        Returns:
+            List of skill summary dicts (id, name, goal, difficulty, step_count, has_code).
+        """
+        logger.info(f"list_skills: doc_id={doc_id}, domain={domain}")
+
+        skills = state.store.list_skills(doc_id=doc_id)
+        if domain:
+            skills = [s for s in skills if s.get("domain") == domain]
+
+        return [
+            {
+                "skill_id": s.get("skill_id"),
+                "name": s.get("name"),
+                "goal": s.get("goal"),
+                "domain": s.get("domain"),
+                "difficulty": s.get("difficulty"),
+                "step_count": s.get("step_count", 0),
+                "has_code": bool(s.get("has_code")),
+                "source_document_id": s.get("source_document_id"),
+            }
+            for s in skills
+        ]
+
+    @mcp.tool()
+    def search_skills(
+        query: str,
+        top_k: int = 5,
+        doc_id: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        """Semantic search over skills. Returns the most relevant how-to procedures.
+
+        Use this when a user asks "how do I X?" — returns the skill(s)
+        whose name/goal/success_criteria best match the query.
+
+        Args:
+            query: Natural language query
+            top_k: Number of results (default: 5)
+            doc_id: Optional filter by source document
+
+        Returns:
+            List of {skill, score, steps} dicts sorted by similarity.
+        """
+        logger.info(f"search_skills: query={query[:50]!r}, top_k={top_k}")
+
+        query_embedding = state.embedder.embed_query(query)
+        results = state.store.search_skills(
+            query_embedding=query_embedding,
+            top_k=top_k,
+            doc_id=doc_id,
+        )
+
+        output = []
+        for skill, score in results:
+            skill_id = skill.get("skill_id", "")
+            steps = state.store.get_skill_steps(skill_id) if skill_id else []
+            entry = _format_skill_with_steps(skill, steps)
+            entry["score"] = score
+            output.append(entry)
+        return output
+
+    @mcp.tool()
+    def get_skill_prerequisites(skill_id: str) -> dict[str, Any]:
+        """Get what must be learned before attempting this skill.
+
+        Returns prerequisite concepts (knowledge needed) and prerequisite
+        skills (other procedures that should be mastered first).
+
+        Args:
+            skill_id: Skill identifier
+
+        Returns:
+            Dict with 'prerequisite_concepts', 'prerequisite_skills', and
+            'produces_concepts' lists.
+        """
+        logger.info(f"get_skill_prerequisites: skill_id={skill_id}")
+
+        skill = state.store.get_skill(skill_id)
+        if not skill:
+            return {"error": f"Skill '{skill_id}' not found"}
+
+        internal_id = skill.get("id")
+        if not internal_id:
+            return {
+                "prerequisite_concepts": [],
+                "prerequisite_skills": [],
+                "produces_concepts": [],
+            }
+
+        return {
+            "skill_id": skill_id,
+            "skill_name": skill.get("name", ""),
+            "prerequisite_concepts": state.store.get_skill_prerequisite_concepts(internal_id),
+            "prerequisite_skills": state.store.get_skill_prerequisite_skills(internal_id),
+            "produces_concepts": state.store.get_skill_produced_concepts(internal_id),
+        }
+
+
+def _format_skill_with_steps(skill: dict, steps: list[dict]) -> dict[str, Any]:
+    """Shape a Skill node + its steps into a clean MCP response dict."""
+    import json as _json
+
+    common_failures_raw = skill.get("common_failures", "[]")
+    try:
+        common_failures = _json.loads(common_failures_raw) if isinstance(common_failures_raw, str) else common_failures_raw
+    except (ValueError, TypeError):
+        common_failures = []
+
+    return {
+        "skill_id": skill.get("skill_id"),
+        "name": skill.get("name"),
+        "goal": skill.get("goal"),
+        "domain": skill.get("domain"),
+        "difficulty": skill.get("difficulty"),
+        "success_criteria": skill.get("success_criteria"),
+        "common_failures": common_failures,
+        "source_document_id": skill.get("source_document_id"),
+        "anchor_header": skill.get("anchor_header"),
+        "step_count": skill.get("step_count", len(steps)),
+        "steps": [
+            {
+                "step_number": s.get("step_number"),
+                "action": s.get("action"),
+                "code_content": s.get("code_content"),
+                "code_language": s.get("code_language"),
+                "expected_output": s.get("expected_output"),
+                "is_optional": bool(s.get("is_optional")),
+            }
+            for s in steps
+        ],
+    }

--- a/src/storage/client.py
+++ b/src/storage/client.py
@@ -320,7 +320,7 @@ class HelixChunkStore:
             data = response.data
             if isinstance(data, dict):
                 # Check for nested node data under various keys
-                for key in ['chunk', 'vec', 'doc', 'node', 'N', 'summary', 'Summary', 'concept', 'Concept']:
+                for key in ['chunk', 'vec', 'doc', 'node', 'N', 'summary', 'Summary', 'concept', 'Concept', 'skill', 'step']:
                     if key in data and isinstance(data[key], dict):
                         node_id = data[key].get('id') or data[key].get('Id')
                         if node_id:

--- a/src/storage/client.py
+++ b/src/storage/client.py
@@ -2161,3 +2161,232 @@ class HelixChunkStore:
             }
             for doc_id, count in doc_counts.items()
         ]
+
+    # ========================================================================
+    # SKILL STORAGE (procedural skill extraction)
+    # ========================================================================
+
+    def store_skill(
+        self,
+        skill_props: dict,
+        steps: list[dict],
+        embedding: Optional[list[float]] = None,
+        embedding_model: str = "unknown",
+        doc_internal_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Store a skill with its steps and optional embedding.
+
+        Args:
+            skill_props: Skill node properties (skill_id, name, goal, ...)
+            steps: List of step dicts (step_id, step_number, action, ...)
+            embedding: Optional embedding vector for the skill
+            embedding_model: Name of the embedding model
+            doc_internal_id: Pre-cached document internal ID
+
+        Returns:
+            Internal skill node ID, or None on failure.
+        """
+        from src.storage.queries import (
+            AddSkill,
+            AddSkillStep,
+            AddSkillVector,
+            GetDocumentByDocId,
+            LinkHasStep,
+            LinkSkillDefinedIn,
+            LinkSkillVector,
+        )
+
+        self._ensure_connected()
+
+        try:
+            add_query = AddSkill(skill_props)
+            response = self._client.query(add_query)
+            skill_internal_id = self._extract_node_id(response)
+            if not skill_internal_id:
+                logger.warning("Failed to get internal ID for skill %r", skill_props.get("skill_id"))
+                return None
+
+            # Store steps, link via HasStep
+            for step in steps:
+                step_query = AddSkillStep(step)
+                step_response = self._client.query(step_query)
+                step_internal_id = self._extract_node_id(step_response)
+                if step_internal_id:
+                    link_query = LinkHasStep(skill_internal_id, step_internal_id)
+                    self._client.query(link_query)
+
+            # Link to source document
+            _doc_id = doc_internal_id
+            doc_string_id = skill_props.get("source_document_id")
+            if not _doc_id and doc_string_id:
+                doc_query = GetDocumentByDocId(doc_string_id)
+                doc_result = self._execute_query(doc_query)
+                if doc_result.success and doc_result.data:
+                    doc_node = doc_result.data.get("node", doc_result.data)
+                    _doc_id = (
+                        self._extract_node_id(doc_result.data)
+                        or (doc_node.get("id") if doc_node else None)
+                    )
+            if _doc_id:
+                link_query = LinkSkillDefinedIn(skill_internal_id, _doc_id)
+                self._client.query(link_query)
+
+            # Add embedding if provided
+            if embedding:
+                vec_query = AddSkillVector(
+                    embedding=embedding,
+                    model_name=embedding_model,
+                    embedding_dim=len(embedding),
+                )
+                vec_response = self._client.query(vec_query)
+                vec_id = self._extract_node_id(vec_response)
+                if vec_id:
+                    link_query = LinkSkillVector(skill_internal_id, vec_id)
+                    self._client.query(link_query)
+
+            return skill_internal_id
+
+        except (ConnectionError, TimeoutError, OSError) as e:
+            logger.error("Network error storing skill %r: %s", skill_props.get("skill_id"), e)
+            raise
+        except Exception:
+            logger.exception("Unexpected error storing skill %r", skill_props.get("skill_id"))
+            raise
+
+    def link_skill_requires_concept(self, skill_internal_id: str, concept_internal_id: str) -> bool:
+        """Link a skill to a prerequisite concept."""
+        from src.storage.queries import LinkRequiresConcept
+
+        self._ensure_connected()
+        result = self._execute_query(LinkRequiresConcept(skill_internal_id, concept_internal_id))
+        return result.success
+
+    def link_skill_produces_concept(self, skill_internal_id: str, concept_internal_id: str) -> bool:
+        """Link a skill to a produced concept."""
+        from src.storage.queries import LinkProducesConcept
+
+        self._ensure_connected()
+        result = self._execute_query(LinkProducesConcept(skill_internal_id, concept_internal_id))
+        return result.success
+
+    def link_skill_requires_skill(self, skill_internal_id: str, prereq_internal_id: str) -> bool:
+        """Link a skill to a prerequisite skill."""
+        from src.storage.queries import LinkRequiresSkill
+
+        self._ensure_connected()
+        result = self._execute_query(LinkRequiresSkill(skill_internal_id, prereq_internal_id))
+        return result.success
+
+    def get_skill(self, skill_id: str) -> Optional[dict]:
+        """Fetch a skill by skill_id."""
+        from src.storage.queries import GetSkillById
+
+        self._ensure_connected()
+        result = self._execute_query(GetSkillById(skill_id))
+        if result.success and result.data:
+            return result.data.get("node")
+        return None
+
+    def get_skill_by_name(self, name: str) -> Optional[dict]:
+        """Fetch a skill by display name."""
+        from src.storage.queries import GetSkillByName
+
+        self._ensure_connected()
+        result = self._execute_query(GetSkillByName(name))
+        if result.success and result.data:
+            return result.data.get("node")
+        return None
+
+    def get_skill_steps(self, skill_id: str) -> list[dict]:
+        """Get all steps for a skill, sorted by step_number."""
+        from src.storage.queries import GetSkillSteps
+
+        self._ensure_connected()
+        result = self._execute_query(GetSkillSteps(skill_id))
+        if not result.success:
+            return []
+        steps = [s for s in (result.data or []) if isinstance(s, dict) and s.get("step_id")]
+        steps.sort(key=lambda s: s.get("step_number", 0))
+        return steps
+
+    def get_skill_prerequisite_concepts(self, skill_internal_id: str) -> list[dict]:
+        """Get concepts the skill requires (prerequisites)."""
+        from src.storage.queries import GetSkillPrerequisiteConcepts
+
+        self._ensure_connected()
+        result = self._execute_query(GetSkillPrerequisiteConcepts(skill_internal_id))
+        return result.data or [] if result.success else []
+
+    def get_skill_produced_concepts(self, skill_internal_id: str) -> list[dict]:
+        """Get concepts the skill produces when executed."""
+        from src.storage.queries import GetSkillProducedConcepts
+
+        self._ensure_connected()
+        result = self._execute_query(GetSkillProducedConcepts(skill_internal_id))
+        return result.data or [] if result.success else []
+
+    def get_skill_prerequisite_skills(self, skill_internal_id: str) -> list[dict]:
+        """Get skills the given skill requires first."""
+        from src.storage.queries import GetSkillPrerequisiteSkills
+
+        self._ensure_connected()
+        result = self._execute_query(GetSkillPrerequisiteSkills(skill_internal_id))
+        return result.data or [] if result.success else []
+
+    def list_skills(self, doc_id: Optional[str] = None) -> list[dict]:
+        """List all skills, optionally filtered by source document."""
+        from src.storage.queries import ListAllSkills, ListDocumentSkills
+
+        self._ensure_connected()
+        if doc_id:
+            result = self._execute_query(ListDocumentSkills(doc_id))
+        else:
+            result = self._execute_query(ListAllSkills())
+        if not result.success:
+            return []
+        return [
+            s for s in (result.data or [])
+            if isinstance(s, dict) and s.get("skill_id")
+        ]
+
+    def search_skills(
+        self,
+        query_embedding: list[float],
+        top_k: int = 10,
+        doc_id: Optional[str] = None,
+    ) -> list[tuple[dict, float]]:
+        """Vector search over skills. Returns list of (skill_node, score).
+
+        Post-filters by doc_id when provided.
+        """
+        from src.storage.queries import GetSkillForVector, SearchSimilarSkills
+
+        self._ensure_connected()
+        vec_result = self._execute_query(
+            SearchSimilarSkills(query_embedding=query_embedding, limit=top_k * 3 if doc_id else top_k)
+        )
+        if not vec_result.success:
+            return []
+
+        out: list[tuple[dict, float]] = []
+        for item in vec_result.data or []:
+            # Each result is a vector node; score may live under different keys
+            node = item if isinstance(item, dict) else {}
+            score = float(node.get("score", node.get("distance", 0.0)) or 0.0)
+            vector_id = node.get("id") or node.get("vector_id") or ""
+            if not vector_id:
+                continue
+            skill_result = self._execute_query(GetSkillForVector(vector_id))
+            if not (skill_result.success and skill_result.data):
+                continue
+            skill_node = skill_result.data
+            if isinstance(skill_node, list):
+                skill_node = skill_node[0] if skill_node else None
+            if not isinstance(skill_node, dict):
+                continue
+            if doc_id and skill_node.get("source_document_id") != doc_id:
+                continue
+            out.append((skill_node, score))
+            if len(out) >= top_k:
+                break
+        return out

--- a/src/storage/client.py
+++ b/src/storage/client.py
@@ -2206,14 +2206,24 @@ class HelixChunkStore:
                 logger.warning("Failed to get internal ID for skill %r", skill_props.get("skill_id"))
                 return None
 
-            # Store steps, link via HasStep
+            # Store steps, link via HasStep. Any failure aborts — we don't
+            # want a skill persisted with missing steps.
             for step in steps:
                 step_query = AddSkillStep(step)
                 step_response = self._client.query(step_query)
                 step_internal_id = self._extract_node_id(step_response)
-                if step_internal_id:
-                    link_query = LinkHasStep(skill_internal_id, step_internal_id)
-                    self._client.query(link_query)
+                if not step_internal_id:
+                    raise RuntimeError(
+                        f"Failed to persist step {step.get('step_id')!r} "
+                        f"for skill {skill_props.get('skill_id')!r}"
+                    )
+                link_query = LinkHasStep(skill_internal_id, step_internal_id)
+                link_result = self._execute_query(link_query)
+                if not link_result.success:
+                    raise RuntimeError(
+                        f"Failed to link step {step.get('step_id')!r} "
+                        f"to skill {skill_props.get('skill_id')!r}"
+                    )
 
             # Link to source document
             _doc_id = doc_internal_id

--- a/src/storage/mock_store.py
+++ b/src/storage/mock_store.py
@@ -542,6 +542,11 @@ class MockChunkStore:
         self._chunks.clear()
         self._embeddings.clear()
         self._model_names.clear()
+        self._skills.clear()
+        self._skill_steps.clear()
+        self._skill_requires_concepts.clear()
+        self._skill_produces_concepts.clear()
+        self._skill_requires_skills.clear()
 
     def get_chunk_internal_id(self, chunk_id: str) -> Optional[str]:
         """Get internal node ID for a chunk_id (mock returns chunk_id as-is).

--- a/src/storage/mock_store.py
+++ b/src/storage/mock_store.py
@@ -35,6 +35,11 @@ class MockChunkStore:
         self._documents: dict[str, dict[str, Any]] = {}
         self._chunks: dict[str, dict[str, Any]] = {}
         self._embeddings: dict[str, list[float]] = {}
+        self._skills: dict[str, dict[str, Any]] = {}
+        self._skill_steps: dict[str, list[dict[str, Any]]] = {}
+        self._skill_requires_concepts: dict[str, list[str]] = {}
+        self._skill_produces_concepts: dict[str, list[str]] = {}
+        self._skill_requires_skills: dict[str, list[str]] = {}
         self._model_names: dict[str, str] = {}
 
     def store_document(
@@ -607,3 +612,72 @@ class MockChunkStore:
             model_name=model_name,
         )
 
+
+    # ========================================================================
+    # Skill storage (in-memory, mirrors HelixChunkStore's interface)
+    # ========================================================================
+
+    def store_skill(
+        self,
+        skill_props: dict,
+        steps: list[dict],
+        embedding: Optional[list[float]] = None,
+        embedding_model: str = "unknown",
+        doc_internal_id: Optional[str] = None,
+    ) -> Optional[str]:
+        skill_id = skill_props.get("skill_id", "")
+        if not skill_id:
+            return None
+        self._skills[skill_id] = dict(skill_props)
+        self._skill_steps[skill_id] = [dict(s) for s in steps]
+        return skill_id
+
+    def link_skill_requires_concept(self, skill_internal_id: str, concept_internal_id: str) -> bool:
+        self._skill_requires_concepts.setdefault(skill_internal_id, []).append(concept_internal_id)
+        return True
+
+    def link_skill_produces_concept(self, skill_internal_id: str, concept_internal_id: str) -> bool:
+        self._skill_produces_concepts.setdefault(skill_internal_id, []).append(concept_internal_id)
+        return True
+
+    def link_skill_requires_skill(self, skill_internal_id: str, prereq_internal_id: str) -> bool:
+        self._skill_requires_skills.setdefault(skill_internal_id, []).append(prereq_internal_id)
+        return True
+
+    def get_skill(self, skill_id: str) -> Optional[dict]:
+        return self._skills.get(skill_id)
+
+    def get_skill_by_name(self, name: str) -> Optional[dict]:
+        for s in self._skills.values():
+            if s.get("name") == name:
+                return s
+        return None
+
+    def get_skill_steps(self, skill_id: str) -> list[dict]:
+        steps = list(self._skill_steps.get(skill_id, []))
+        steps.sort(key=lambda s: s.get("step_number", 0))
+        return steps
+
+    def get_skill_prerequisite_concepts(self, skill_internal_id: str) -> list[dict]:
+        return [{"concept_id": cid} for cid in self._skill_requires_concepts.get(skill_internal_id, [])]
+
+    def get_skill_produced_concepts(self, skill_internal_id: str) -> list[dict]:
+        return [{"concept_id": cid} for cid in self._skill_produces_concepts.get(skill_internal_id, [])]
+
+    def get_skill_prerequisite_skills(self, skill_internal_id: str) -> list[dict]:
+        return [{"skill_id": sid} for sid in self._skill_requires_skills.get(skill_internal_id, [])]
+
+    def list_skills(self, doc_id: Optional[str] = None) -> list[dict]:
+        all_skills = list(self._skills.values())
+        if doc_id:
+            return [s for s in all_skills if s.get("source_document_id") == doc_id]
+        return all_skills
+
+    def search_skills(
+        self,
+        query_embedding: list[float],
+        top_k: int = 10,
+        doc_id: Optional[str] = None,
+    ) -> list[tuple[dict, float]]:
+        skills = self.list_skills(doc_id=doc_id)
+        return [(s, 1.0) for s in skills[:top_k]]

--- a/src/storage/queries.py
+++ b/src/storage/queries.py
@@ -2060,3 +2060,368 @@ class ListSummarizedDocuments(_get_query_base_class()):
         if isinstance(response, list):
             return QueryResult(success=True, data=response)
         return QueryResult(success=True, data=[])
+
+
+# ============================================================================
+# SKILL QUERIES (Procedural skill extraction)
+# ============================================================================
+
+
+class AddSkill(_get_query_base_class()):
+    """Add a skill node to the database."""
+
+    def __init__(self, skill_props: dict[str, Any]) -> None:
+        super().__init__(endpoint="AddSkill")
+        self.skill_props = skill_props
+
+    def query(self) -> list[dict[str, Any]]:
+        p = self.skill_props
+        return [{
+            "skill_id": p.get("skill_id", ""),
+            "name": p.get("name", ""),
+            "goal": p.get("goal", ""),
+            "domain": p.get("domain", "general"),
+            "difficulty": p.get("difficulty", "intermediate"),
+            "source_document_id": p.get("source_document_id", ""),
+            "anchor_header": p.get("anchor_header", ""),
+            "source_chunk_ids": p.get("source_chunk_ids", "[]"),
+            "success_criteria": p.get("success_criteria", ""),
+            "common_failures": p.get("common_failures", "[]"),
+            "step_count": p.get("step_count", 0),
+            "has_code": p.get("has_code", 0),
+            "created_at": p.get("created_at", int(time.time())),
+        }]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "skill" in response:
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data={"skill_id": self.skill_props.get("skill_id")})
+
+
+class AddSkillStep(_get_query_base_class()):
+    """Add a skill step node."""
+
+    def __init__(self, step_props: dict[str, Any]) -> None:
+        super().__init__(endpoint="AddSkillStep")
+        self.step_props = step_props
+
+    def query(self) -> list[dict[str, Any]]:
+        p = self.step_props
+        return [{
+            "step_id": p.get("step_id", ""),
+            "skill_id": p.get("skill_id", ""),
+            "step_number": p.get("step_number", 0),
+            "action": p.get("action", ""),
+            "code_content": p.get("code_content", ""),
+            "code_language": p.get("code_language", ""),
+            "expected_output": p.get("expected_output", ""),
+            "is_optional": p.get("is_optional", 0),
+        }]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "step" in response:
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data={"step_id": self.step_props.get("step_id")})
+
+
+class AddSkillVector(_get_query_base_class()):
+    """Add vector embedding for a skill."""
+
+    def __init__(self, embedding: list[float], model_name: str, embedding_dim: int) -> None:
+        super().__init__(endpoint="AddSkillVector")
+        self.embedding = embedding
+        self.model_name = model_name
+        self.embedding_dim = embedding_dim
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{
+            "embedding": self.embedding,
+            "model_name": self.model_name,
+            "embedding_dim": self.embedding_dim,
+        }]
+
+    def response(self, response: Any) -> QueryResult:
+        return QueryResult(success=True, data=response)
+
+
+class LinkHasStep(_get_query_base_class()):
+    """Link skill to a step via HasStep edge."""
+
+    def __init__(self, skill_id: str, step_id: str) -> None:
+        super().__init__(endpoint="LinkHasStep")
+        self.skill_id = skill_id
+        self.step_id = step_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id, "step_id": self.step_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        return QueryResult(success=True, data=response)
+
+
+class LinkRequiresConcept(_get_query_base_class()):
+    """Link skill to a prerequisite concept."""
+
+    def __init__(self, skill_id: str, concept_id: str) -> None:
+        super().__init__(endpoint="LinkRequiresConcept")
+        self.skill_id = skill_id
+        self.concept_id = concept_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id, "concept_id": self.concept_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        return QueryResult(success=True, data=response)
+
+
+class LinkProducesConcept(_get_query_base_class()):
+    """Link skill to a produced concept."""
+
+    def __init__(self, skill_id: str, concept_id: str) -> None:
+        super().__init__(endpoint="LinkProducesConcept")
+        self.skill_id = skill_id
+        self.concept_id = concept_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id, "concept_id": self.concept_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        return QueryResult(success=True, data=response)
+
+
+class LinkRequiresSkill(_get_query_base_class()):
+    """Link skill to a prerequisite skill."""
+
+    def __init__(self, skill_id: str, prereq_id: str) -> None:
+        super().__init__(endpoint="LinkRequiresSkill")
+        self.skill_id = skill_id
+        self.prereq_id = prereq_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id, "prereq_id": self.prereq_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        return QueryResult(success=True, data=response)
+
+
+class LinkSkillDefinedIn(_get_query_base_class()):
+    """Link skill to its source document."""
+
+    def __init__(self, skill_id: str, doc_id: str) -> None:
+        super().__init__(endpoint="LinkSkillDefinedIn")
+        self.skill_id = skill_id
+        self.doc_id = doc_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id, "doc_id": self.doc_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        return QueryResult(success=True, data=response)
+
+
+class LinkSkillVector(_get_query_base_class()):
+    """Link skill to its embedding vector."""
+
+    def __init__(self, skill_id: str, vector_id: str) -> None:
+        super().__init__(endpoint="LinkSkillVector")
+        self.skill_id = skill_id
+        self.vector_id = vector_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id, "vector_id": self.vector_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        return QueryResult(success=True, data=response)
+
+
+class GetSkillById(_get_query_base_class()):
+    """Get a skill by skill_id."""
+
+    def __init__(self, skill_id: str) -> None:
+        super().__init__(endpoint="GetSkillById")
+        self.skill_id = skill_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "skills" in response:
+            skills = response["skills"]
+            if isinstance(skills, list) and skills:
+                return QueryResult(success=True, data={"node": skills[0]})
+        if isinstance(response, list) and response:
+            return QueryResult(success=True, data={"node": response[0]})
+        return QueryResult(success=False, error="Skill not found")
+
+
+class GetSkillByName(_get_query_base_class()):
+    """Get a skill by display name."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(endpoint="GetSkillByName")
+        self.name = name
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"name": self.name}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "skills" in response:
+            skills = response["skills"]
+            if isinstance(skills, list) and skills:
+                return QueryResult(success=True, data={"node": skills[0]})
+        if isinstance(response, list) and response:
+            return QueryResult(success=True, data={"node": response[0]})
+        return QueryResult(success=False, error="Skill not found")
+
+
+class GetSkillSteps(_get_query_base_class()):
+    """Get all steps for a skill."""
+
+    def __init__(self, skill_id: str) -> None:
+        super().__init__(endpoint="GetSkillSteps")
+        self.skill_id = skill_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "steps" in response:
+            steps = response["steps"]
+            if isinstance(steps, list):
+                return QueryResult(success=True, data=steps)
+        if isinstance(response, list):
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data=[])
+
+
+class GetSkillPrerequisiteConcepts(_get_query_base_class()):
+    """Get prerequisite concepts for a skill."""
+
+    def __init__(self, skill_id: str) -> None:
+        super().__init__(endpoint="GetSkillPrerequisiteConcepts")
+        self.skill_id = skill_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "concepts" in response:
+            return QueryResult(success=True, data=response["concepts"] or [])
+        if isinstance(response, list):
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data=[])
+
+
+class GetSkillProducedConcepts(_get_query_base_class()):
+    """Get produced concepts for a skill."""
+
+    def __init__(self, skill_id: str) -> None:
+        super().__init__(endpoint="GetSkillProducedConcepts")
+        self.skill_id = skill_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "concepts" in response:
+            return QueryResult(success=True, data=response["concepts"] or [])
+        if isinstance(response, list):
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data=[])
+
+
+class GetSkillPrerequisiteSkills(_get_query_base_class()):
+    """Get prerequisite skills for a skill."""
+
+    def __init__(self, skill_id: str) -> None:
+        super().__init__(endpoint="GetSkillPrerequisiteSkills")
+        self.skill_id = skill_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"skill_id": self.skill_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "skills" in response:
+            return QueryResult(success=True, data=response["skills"] or [])
+        if isinstance(response, list):
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data=[])
+
+
+class ListAllSkills(_get_query_base_class()):
+    """List all skill nodes."""
+
+    def __init__(self) -> None:
+        super().__init__(endpoint="ListAllSkills")
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "skills" in response:
+            return QueryResult(success=True, data=response["skills"] or [])
+        if isinstance(response, list):
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data=[])
+
+
+class ListDocumentSkills(_get_query_base_class()):
+    """List all skills for a document."""
+
+    def __init__(self, source_document_id: str) -> None:
+        super().__init__(endpoint="ListDocumentSkills")
+        self.source_document_id = source_document_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"source_document_id": self.source_document_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "skills" in response:
+            return QueryResult(success=True, data=response["skills"] or [])
+        if isinstance(response, list):
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data=[])
+
+
+class GetSkillForVector(_get_query_base_class()):
+    """Get the skill linked to a vector (reverse lookup)."""
+
+    def __init__(self, vector_id: str) -> None:
+        super().__init__(endpoint="GetSkillForVector")
+        self.vector_id = vector_id
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"vector_id": self.vector_id}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "skill" in response:
+            node = response["skill"]
+            if isinstance(node, list) and node:
+                return QueryResult(success=True, data=node[0])
+            return QueryResult(success=True, data=node)
+        if isinstance(response, list) and response:
+            return QueryResult(success=True, data=response[0])
+        return QueryResult(success=True, data=response)
+
+
+class SearchSimilarSkills(_get_query_base_class()):
+    """Vector similarity search over skills."""
+
+    def __init__(
+        self,
+        query_embedding: list[float],
+        limit: int = 10,
+    ) -> None:
+        super().__init__(endpoint="SearchSimilarSkills")
+        self.query_embedding = query_embedding
+        self.limit = limit
+
+    def query(self) -> list[dict[str, Any]]:
+        return [{"query_vec": self.query_embedding, "top_k": self.limit}]
+
+    def response(self, response: Any) -> QueryResult:
+        if isinstance(response, dict) and "results" in response:
+            return QueryResult(success=True, data=response["results"])
+        if isinstance(response, list):
+            return QueryResult(success=True, data=response)
+        return QueryResult(success=True, data=[])

--- a/tests/test_skill_synthesizer.py
+++ b/tests/test_skill_synthesizer.py
@@ -1,0 +1,141 @@
+"""Tests for LLM-based skill enrichment (Instructor mocked)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.chunker.skills import AssembledSkill, RawStep, SkillBoundary
+
+
+def _sample_skill() -> AssembledSkill:
+    boundary = SkillBoundary(
+        anchor_header="How to Deploy an App",
+        anchor_header_level=2,
+        chunk_ids=["c1", "c2"],
+        start_chunk_id="c1",
+        end_chunk_id="c2",
+        document_id="kubernetes_guide",
+    )
+    steps = [
+        RawStep(
+            step_number=1,
+            action="Create a deployment manifest",
+            code_content="apiVersion: apps/v1\nkind: Deployment",
+            code_language="yaml",
+        ),
+        RawStep(
+            step_number=2,
+            action="Apply the manifest",
+            code_content="kubectl apply -f deploy.yaml",
+            code_language="bash",
+            expected_output="deployment.apps/my-app created",
+        ),
+    ]
+    return AssembledSkill(boundary=boundary, steps=steps, raw_markdown="...")
+
+
+@patch("src.chunker.skill_synthesizer.INSTRUCTOR_AVAILABLE", False)
+def test_init_raises_without_instructor():
+    from src.chunker.skill_synthesizer import SkillSynthesizer
+
+    with pytest.raises(ImportError, match="instructor is not installed"):
+        SkillSynthesizer()
+
+
+@patch("src.chunker.skill_synthesizer.INSTRUCTOR_AVAILABLE", True)
+@patch("src.chunker.skill_synthesizer.instructor")
+class TestSkillSynthesizer:
+    def test_enrich_single_skill(self, mock_instructor):
+        from src.chunker.skill_synthesizer import EnrichedSkillMetadata, SkillSynthesizer
+
+        mock_client = MagicMock()
+        mock_instructor.from_provider.return_value = mock_client
+
+        expected = EnrichedSkillMetadata(
+            name="Deploy app to Kubernetes",
+            goal="Run a pod matching the deployment spec",
+            difficulty="intermediate",
+            success_criteria="Pods in Running state",
+            common_failures=[],
+            prerequisite_concepts=["Pod", "Deployment"],
+            prerequisite_skills=["Install kubectl"],
+            produces_concepts=["Running Pod"],
+        )
+        mock_client.chat.completions.create.return_value = expected
+
+        synth = SkillSynthesizer(provider="openai/gpt-4o-mini")
+        result = synth.enrich(_sample_skill(), known_concepts=["Pod", "Deployment", "Service"])
+
+        assert result.name == "Deploy app to Kubernetes"
+        assert result.difficulty == "intermediate"
+        assert result.prerequisite_concepts == ["Pod", "Deployment"]
+        assert mock_client.chat.completions.create.call_count == 1
+
+    def test_system_prompt_includes_profile_hints(self, mock_instructor):
+        from src.chunker.profiles import get_profile
+        from src.chunker.skill_synthesizer import SkillSynthesizer
+
+        mock_instructor.from_provider.return_value = MagicMock()
+
+        profile = get_profile("programming")
+        synth = SkillSynthesizer(provider="openai/gpt-4o-mini", profile=profile)
+        prompt = synth._system_prompt()
+        assert "programming" in prompt.lower() or "code" in prompt.lower()
+
+    def test_user_prompt_formats_steps(self, mock_instructor):
+        from src.chunker.skill_synthesizer import SkillSynthesizer
+
+        mock_instructor.from_provider.return_value = MagicMock()
+        synth = SkillSynthesizer()
+        prompt = synth._user_prompt(_sample_skill(), known_concepts=["Pod"])
+
+        assert "ANCHOR HEADER: How to Deploy an App" in prompt
+        assert "1. Create a deployment manifest" in prompt
+        assert "2. Apply the manifest" in prompt
+        assert "```yaml" in prompt
+        assert "kubectl apply" in prompt
+        assert "Pod" in prompt
+
+    def test_enrich_all_handles_failures(self, mock_instructor):
+        from src.chunker.skill_synthesizer import SkillSynthesizer
+
+        mock_client = MagicMock()
+        mock_instructor.from_provider.return_value = mock_client
+        # First call succeeds, second raises
+        from src.chunker.skill_synthesizer import EnrichedSkillMetadata
+
+        good = EnrichedSkillMetadata(
+            name="Good Skill",
+            goal="Do something",
+            difficulty="beginner",
+            success_criteria="Works",
+        )
+        mock_client.chat.completions.create.side_effect = [good, RuntimeError("rate limit")]
+
+        synth = SkillSynthesizer()
+        skills = [_sample_skill(), _sample_skill()]
+        results = synth.enrich_all(skills)
+
+        assert len(results) == 2
+        assert results[0]["metadata"]["name"] == "Good Skill"
+        assert results[0]["enrichment_error"] is None
+        assert results[1]["metadata"] is None
+        assert "rate limit" in results[1]["enrichment_error"]
+
+    def test_enrich_all_preserves_raw_steps(self, mock_instructor):
+        """LLM only fills metadata; raw steps must pass through unchanged."""
+        from src.chunker.skill_synthesizer import EnrichedSkillMetadata, SkillSynthesizer
+
+        mock_client = MagicMock()
+        mock_instructor.from_provider.return_value = mock_client
+        mock_client.chat.completions.create.return_value = EnrichedSkillMetadata(
+            name="x", goal="x", difficulty="beginner", success_criteria="x",
+        )
+
+        synth = SkillSynthesizer()
+        skills = [_sample_skill()]
+        results = synth.enrich_all(skills)
+
+        # Steps dict should match original code/language verbatim
+        assert results[0]["steps"][1]["code_content"] == "kubectl apply -f deploy.yaml"
+        assert results[0]["steps"][1]["code_language"] == "bash"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,342 @@
+"""Tests for procedural skill extraction (detection + assembly)."""
+
+from src.chunker.skills import (
+    AssembledSkill,
+    RawStep,
+    SkillBoundary,
+    assemble_skill_steps,
+    detect_skill_boundaries,
+    extract_skills,
+)
+
+
+def _chunk(
+    chunk_id: str,
+    content: str,
+    header_text: str | None = None,
+    header_level: int | None = None,
+    prev_id: str | None = None,
+    next_id: str | None = None,
+    document_id: str = "doc1",
+) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "content": content,
+        "header_text": header_text,
+        "header_level": header_level,
+        "prev_id": prev_id,
+        "next_id": next_id,
+        "document_id": document_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Phase A: Detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSkillBoundaries:
+    def test_empty_chunks(self):
+        assert detect_skill_boundaries([]) == []
+
+    def test_no_anchor_headers(self):
+        chunks = [
+            _chunk("c1", "Some narrative text."),
+            _chunk("c2", "More text without step markers."),
+        ]
+        assert detect_skill_boundaries(chunks) == []
+
+    def test_how_to_header_with_numbered_steps(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "## How to Deploy\n\n1. Create manifest\n2. Apply manifest",
+                header_text="How to Deploy",
+                header_level=2,
+                next_id="c2",
+            ),
+            _chunk(
+                "c2",
+                "Now the pods are running.",
+                prev_id="c1",
+            ),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        assert len(boundaries) == 1
+        assert boundaries[0].anchor_header == "How to Deploy"
+        assert boundaries[0].start_chunk_id == "c1"
+
+    def test_to_verb_colon_header(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "To install kubectl:\n\n1. Download binary\n2. Make executable",
+                header_text="To install kubectl:",
+                header_level=3,
+            ),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        assert len(boundaries) == 1
+
+    def test_stops_at_sibling_header(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "1. Step one\n2. Step two",
+                header_text="How to Deploy",
+                header_level=2,
+                next_id="c2",
+            ),
+            _chunk(
+                "c2",
+                "Different topic here",
+                header_text="How to Delete",
+                header_level=2,
+                prev_id="c1",
+                next_id="c3",
+            ),
+            _chunk("c3", "More", prev_id="c2"),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        # Both anchors detected; first should stop at second's header
+        assert len(boundaries) >= 1
+        first = boundaries[0]
+        assert "c2" not in first.chunk_ids
+
+    def test_insufficient_signal_rejected(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "Just some prose without steps or code.",
+                header_text="How to Relax",
+                header_level=2,
+            ),
+        ]
+        assert detect_skill_boundaries(chunks) == []
+
+    def test_code_fence_plus_one_step_accepted(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "## How to Build\n\n1. Run the command\n\n```bash\nmake build\n```",
+                header_text="How to Build",
+                header_level=2,
+            ),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        assert len(boundaries) == 1
+
+    def test_walks_next_id_chain(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "1. First step",
+                header_text="How to X",
+                header_level=2,
+                next_id="c2",
+            ),
+            _chunk("c2", "2. Second step\n3. Third step", prev_id="c1", next_id="c3"),
+            _chunk("c3", "```yaml\nkey: value\n```", prev_id="c2"),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        assert len(boundaries) == 1
+        assert boundaries[0].chunk_ids == ["c1", "c2", "c3"]
+
+
+# ---------------------------------------------------------------------------
+# Phase B: Assembly
+# ---------------------------------------------------------------------------
+
+
+class TestAssembleSkillSteps:
+    def test_parses_numbered_steps(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "1. First do this\n2. Then do that\n3. Finally do the other",
+                header_text="How to X",
+                header_level=2,
+            ),
+        ]
+        boundary = SkillBoundary(
+            anchor_header="How to X",
+            anchor_header_level=2,
+            chunk_ids=["c1"],
+            start_chunk_id="c1",
+            end_chunk_id="c1",
+        )
+        result = assemble_skill_steps(boundary, chunks)
+        assert len(result.steps) == 3
+        assert result.steps[0].action == "First do this"
+        assert result.steps[1].action == "Then do that"
+        assert result.steps[2].action == "Finally do the other"
+
+    def test_extracts_code_block(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "1. Run the apply command:\n\n```bash\nkubectl apply -f deploy.yaml\n```",
+                header_text="How to Deploy",
+                header_level=2,
+            ),
+        ]
+        boundary = SkillBoundary(
+            anchor_header="How to Deploy",
+            anchor_header_level=2,
+            chunk_ids=["c1"],
+        )
+        result = assemble_skill_steps(boundary, chunks)
+        assert len(result.steps) == 1
+        step = result.steps[0]
+        assert "Run the apply command" in step.action
+        assert step.code_content == "kubectl apply -f deploy.yaml"
+        assert step.code_language == "bash"
+
+    def test_extracts_expected_output_marker(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "1. Check status:\n\n```bash\nkubectl get pods\n```\n\nOutput: STATUS Running",
+                header_text="How to Check",
+                header_level=2,
+            ),
+        ]
+        boundary = SkillBoundary(
+            anchor_header="How to Check",
+            anchor_header_level=2,
+            chunk_ids=["c1"],
+        )
+        result = assemble_skill_steps(boundary, chunks)
+        assert len(result.steps) == 1
+        assert "STATUS Running" in result.steps[0].expected_output
+
+    def test_extracts_output_from_second_fence(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "1. Run:\n\n```bash\necho hi\n```\n\n```console\nhi\n```",
+                header_text="How to Echo",
+                header_level=2,
+            ),
+        ]
+        boundary = SkillBoundary(
+            anchor_header="How to Echo",
+            anchor_header_level=2,
+            chunk_ids=["c1"],
+        )
+        result = assemble_skill_steps(boundary, chunks)
+        assert result.steps[0].code_content == "echo hi"
+        assert result.steps[0].expected_output == "hi"
+
+    def test_step_word_markers(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "Step 1: Open the file\nStep 2: Read the data\nStep 3: Close the file",
+                header_text="How to Process",
+                header_level=2,
+            ),
+        ]
+        boundary = SkillBoundary(
+            anchor_header="How to Process",
+            anchor_header_level=2,
+            chunk_ids=["c1"],
+        )
+        result = assemble_skill_steps(boundary, chunks)
+        assert len(result.steps) == 3
+        assert result.steps[0].action == "Open the file"
+        assert result.steps[1].action == "Read the data"
+
+    def test_renumbers_sequentially(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "5. Skip number\n6. Another\n7. Third",
+                header_text="How to X",
+                header_level=2,
+            ),
+        ]
+        boundary = SkillBoundary(
+            anchor_header="How to X",
+            anchor_header_level=2,
+            chunk_ids=["c1"],
+        )
+        result = assemble_skill_steps(boundary, chunks)
+        assert [s.step_number for s in result.steps] == [1, 2, 3]
+
+    def test_fallback_imperative_parser(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "Run the installer.\n\nConfigure the credentials.\n\nStart the service.",
+                header_text="How to Setup",
+                header_level=2,
+            ),
+        ]
+        boundary = SkillBoundary(
+            anchor_header="How to Setup",
+            anchor_header_level=2,
+            chunk_ids=["c1"],
+        )
+        result = assemble_skill_steps(boundary, chunks)
+        # Fallback should find 3 imperative paragraphs
+        assert len(result.steps) == 3
+
+
+# ---------------------------------------------------------------------------
+# End-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSkills:
+    def test_full_pipeline(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "## How to Deploy an App\n\nThis section shows how to deploy.",
+                header_text="How to Deploy an App",
+                header_level=2,
+                next_id="c2",
+            ),
+            _chunk(
+                "c2",
+                "1. Create the manifest:\n\n```yaml\nkind: Deployment\n```",
+                prev_id="c1",
+                next_id="c3",
+            ),
+            _chunk(
+                "c3",
+                "2. Apply it:\n\n```bash\nkubectl apply -f deploy.yaml\n```",
+                prev_id="c2",
+            ),
+        ]
+        skills = extract_skills(chunks)
+        assert len(skills) == 1
+        skill = skills[0]
+        assert skill.boundary.anchor_header == "How to Deploy an App"
+        assert len(skill.steps) == 2
+        assert skill.steps[0].code_language == "yaml"
+        assert skill.steps[1].code_language == "bash"
+        assert "kubectl apply" in skill.steps[1].code_content
+
+    def test_multiple_skills_in_document(self):
+        chunks = [
+            _chunk(
+                "c1",
+                "1. Step A\n2. Step B",
+                header_text="How to Deploy",
+                header_level=2,
+                next_id="c2",
+            ),
+            _chunk(
+                "c2",
+                "1. Step X\n2. Step Y",
+                header_text="How to Delete",
+                header_level=2,
+                prev_id="c1",
+            ),
+        ]
+        skills = extract_skills(chunks)
+        assert len(skills) == 2
+        assert skills[0].boundary.anchor_header == "How to Deploy"
+        assert skills[1].boundary.anchor_header == "How to Delete"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -247,6 +247,45 @@ class TestAssembleSkillSteps:
         assert result.steps[0].action == "Open the file"
         assert result.steps[1].action == "Read the data"
 
+    def test_detects_step_word_markers_at_boundary(self):
+        """Phase A should count 'Step N:' markers, not only '1.' markers."""
+        chunks = [
+            _chunk(
+                "c1",
+                "Step 1: Open\nStep 2: Read\nStep 3: Close",
+                header_text="How to Process",
+                header_level=2,
+            ),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        assert len(boundaries) == 1
+
+    def test_detects_paren_step_markers_at_boundary(self):
+        """Phase A should count '1)' markers, not only '1.' markers."""
+        chunks = [
+            _chunk(
+                "c1",
+                "1) First\n2) Second\n3) Third",
+                header_text="How to Setup",
+                header_level=2,
+            ),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        assert len(boundaries) == 1
+
+    def test_detects_boundary_with_only_code_fences(self):
+        """Two code fences + imperative text should pass the body-signal gate."""
+        chunks = [
+            _chunk(
+                "c1",
+                "Run the build:\n\n```bash\nmake\n```\n\nRun tests:\n\n```bash\nmake test\n```",
+                header_text="How to Build",
+                header_level=2,
+            ),
+        ]
+        boundaries = detect_skill_boundaries(chunks)
+        assert len(boundaries) == 1
+
     def test_renumbers_sequentially(self):
         chunks = [
             _chunk(

--- a/tests/test_skills_storage.py
+++ b/tests/test_skills_storage.py
@@ -1,0 +1,159 @@
+"""Tests for skill storage (MockChunkStore) and MCP tool formatting."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.storage.mock_store import MockChunkStore
+
+
+def _skill_props(**overrides) -> dict:
+    base = {
+        "skill_id": "deploy-app",
+        "name": "Deploy app",
+        "goal": "Running pods",
+        "domain": "programming",
+        "difficulty": "intermediate",
+        "source_document_id": "doc1",
+        "anchor_header": "How to Deploy",
+        "source_chunk_ids": json.dumps(["c1", "c2"]),
+        "success_criteria": "Pods running",
+        "common_failures": json.dumps([]),
+        "step_count": 2,
+        "has_code": 1,
+        "created_at": 123456,
+    }
+    base.update(overrides)
+    return base
+
+
+def _step(step_id: str, step_number: int, action: str, **overrides) -> dict:
+    base = {
+        "step_id": step_id,
+        "skill_id": "deploy-app",
+        "step_number": step_number,
+        "action": action,
+        "code_content": "",
+        "code_language": "",
+        "expected_output": "",
+        "is_optional": 0,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestMockSkillStorage:
+    def test_round_trip_store_and_get(self):
+        store = MockChunkStore()
+        steps = [
+            _step("s1", 1, "Create manifest", code_content="kind: Deployment", code_language="yaml"),
+            _step("s2", 2, "Apply it", code_content="kubectl apply", code_language="bash"),
+        ]
+        sid = store.store_skill(_skill_props(), steps)
+        assert sid == "deploy-app"
+
+        skill = store.get_skill("deploy-app")
+        assert skill is not None
+        assert skill["name"] == "Deploy app"
+        assert skill["difficulty"] == "intermediate"
+
+        out_steps = store.get_skill_steps("deploy-app")
+        assert len(out_steps) == 2
+        assert out_steps[0]["step_number"] == 1
+        assert out_steps[1]["code_language"] == "bash"
+
+    def test_get_skill_by_name(self):
+        store = MockChunkStore()
+        store.store_skill(_skill_props(), [])
+        found = store.get_skill_by_name("Deploy app")
+        assert found is not None
+        assert found["skill_id"] == "deploy-app"
+        assert store.get_skill_by_name("Nonexistent") is None
+
+    def test_list_skills_filter_by_doc(self):
+        store = MockChunkStore()
+        store.store_skill(_skill_props(skill_id="a", name="A", source_document_id="doc1"), [])
+        store.store_skill(_skill_props(skill_id="b", name="B", source_document_id="doc2"), [])
+
+        all_skills = store.list_skills()
+        assert len(all_skills) == 2
+
+        doc1_skills = store.list_skills(doc_id="doc1")
+        assert len(doc1_skills) == 1
+        assert doc1_skills[0]["skill_id"] == "a"
+
+    def test_steps_sorted_by_number(self):
+        store = MockChunkStore()
+        steps = [
+            _step("s3", 3, "Third"),
+            _step("s1", 1, "First"),
+            _step("s2", 2, "Second"),
+        ]
+        store.store_skill(_skill_props(), steps)
+        ordered = store.get_skill_steps("deploy-app")
+        assert [s["step_number"] for s in ordered] == [1, 2, 3]
+
+    def test_link_prerequisite_concept(self):
+        store = MockChunkStore()
+        store.store_skill(_skill_props(), [])
+        assert store.link_skill_requires_concept("deploy-app", "pod-concept")
+        prereqs = store.get_skill_prerequisite_concepts("deploy-app")
+        assert {"concept_id": "pod-concept"} in prereqs
+
+    def test_link_produces_concept(self):
+        store = MockChunkStore()
+        store.store_skill(_skill_props(), [])
+        store.link_skill_produces_concept("deploy-app", "running-pod")
+        produces = store.get_skill_produced_concepts("deploy-app")
+        assert produces == [{"concept_id": "running-pod"}]
+
+
+class TestMCPFormatter:
+    def test_format_skill_with_steps(self):
+        from src.mcp_server.tools import _format_skill_with_steps
+
+        skill = {
+            "skill_id": "deploy",
+            "name": "Deploy",
+            "goal": "ship it",
+            "domain": "programming",
+            "difficulty": "beginner",
+            "success_criteria": "works",
+            "common_failures": json.dumps([{"symptom": "x", "resolution": "y"}]),
+            "source_document_id": "doc1",
+            "anchor_header": "How to Deploy",
+            "step_count": 1,
+        }
+        steps = [
+            {
+                "step_number": 1,
+                "action": "Run",
+                "code_content": "make",
+                "code_language": "bash",
+                "expected_output": "done",
+                "is_optional": 0,
+            },
+        ]
+        out = _format_skill_with_steps(skill, steps)
+        assert out["name"] == "Deploy"
+        assert out["common_failures"] == [{"symptom": "x", "resolution": "y"}]
+        assert out["step_count"] == 1
+        assert len(out["steps"]) == 1
+        assert out["steps"][0]["is_optional"] is False
+
+    def test_format_handles_invalid_json_common_failures(self):
+        from src.mcp_server.tools import _format_skill_with_steps
+
+        skill = {"skill_id": "x", "name": "X", "common_failures": "not-json"}
+        out = _format_skill_with_steps(skill, [])
+        assert out["common_failures"] == []
+
+
+class TestGenerateSkillId:
+    def test_slugify_via_cli(self):
+        from src.cli.commands.skills import _slugify
+
+        assert _slugify("Deploy App to Kubernetes") == "deploy-app-to-kubernetes"
+        assert _slugify("How to Use `kubectl`!") == "how-to-use-kubectl"
+        assert _slugify("   ") == "unnamed-skill"

--- a/tests/test_skills_storage.py
+++ b/tests/test_skills_storage.py
@@ -108,6 +108,34 @@ class TestMockSkillStorage:
         produces = store.get_skill_produced_concepts("deploy-app")
         assert produces == [{"concept_id": "running-pod"}]
 
+    def test_link_requires_skill(self):
+        store = MockChunkStore()
+        store.store_skill(_skill_props(), [])
+        store.store_skill(_skill_props(skill_id="install", name="Install kubectl"), [])
+        store.link_skill_requires_skill("deploy-app", "install")
+        prereqs = store.get_skill_prerequisite_skills("deploy-app")
+        assert prereqs == [{"skill_id": "install"}]
+
+    def test_clear_resets_skill_state(self):
+        """clear() must reset skill-related maps so tests don't leak state."""
+        store = MockChunkStore()
+        store.store_skill(_skill_props(), [_step("s1", 1, "A")])
+        store.link_skill_requires_concept("deploy-app", "pod")
+        store.link_skill_produces_concept("deploy-app", "running-pod")
+        store.link_skill_requires_skill("deploy-app", "install")
+
+        assert store.list_skills()
+        assert store.get_skill_steps("deploy-app")
+
+        store.clear()
+
+        assert store.list_skills() == []
+        assert store.get_skill("deploy-app") is None
+        assert store.get_skill_steps("deploy-app") == []
+        assert store.get_skill_prerequisite_concepts("deploy-app") == []
+        assert store.get_skill_produced_concepts("deploy-app") == []
+        assert store.get_skill_prerequisite_skills("deploy-app") == []
+
 
 class TestMCPFormatter:
     def test_format_skill_with_steps(self):

--- a/tests/test_skills_storage.py
+++ b/tests/test_skills_storage.py
@@ -137,6 +137,7 @@ class TestMockSkillStorage:
         assert store.get_skill_prerequisite_skills("deploy-app") == []
 
 
+@pytest.mark.mcp
 class TestMCPFormatter:
     def test_format_skill_with_steps(self):
         from src.mcp_server.tools import _format_skill_with_steps
@@ -185,3 +186,24 @@ class TestGenerateSkillId:
         assert _slugify("Deploy App to Kubernetes") == "deploy-app-to-kubernetes"
         assert _slugify("How to Use `kubectl`!") == "how-to-use-kubectl"
         assert _slugify("   ") == "unnamed-skill"
+
+    def test_collision_counter_logic(self):
+        """Per-batch counter should disambiguate same-name skills in one doc."""
+        from src.cli.commands.skills import _slugify
+
+        used_skill_ids: dict[str, int] = {}
+        names = ["Deploy App", "Deploy App", "Deploy App", "Other Skill"]
+        doc_scope = _slugify("k8s-guide")
+        result = []
+        for name in names:
+            base = f"{doc_scope}__{_slugify(name)}"
+            seen = used_skill_ids.get(base, 0)
+            sid = base if seen == 0 else f"{base}_{seen + 1}"
+            used_skill_ids[base] = seen + 1
+            result.append(sid)
+        assert result == [
+            "k8s-guide__deploy-app",
+            "k8s-guide__deploy-app_2",
+            "k8s-guide__deploy-app_3",
+            "k8s-guide__other-skill",
+        ]


### PR DESCRIPTION
## Summary
Adds a **Skill** as a first-class entity: named, ordered, executable procedures extracted from textbook chunks with prerequisites, code snippets, and verification criteria. Agents can now answer "how do I X?" with an actionable recipe instead of fragmented reading material.

## Pipeline (3 phases → 3 commits)

### 1. Detect + Assemble (`src/chunker/skills.py`)
- Finds "How to" / "Steps to" / "Tutorial" / "To X:" headers as skill anchors
- Walks `next_id` chain with density/sibling termination
- Re-parses raw markdown into ordered `RawStep` objects with code fences and expected outputs
- **No LLM, no DB** — deterministic parser, reviewable JSON output

### 2. Enrich (`src/chunker/skill_synthesizer.py`)
- Single Instructor call per skill produces name, goal, difficulty, prerequisites, common failures
- **Raw steps preserved verbatim** — LLM only fills metadata, code stays exactly as the book wrote it
- Profile-aware prompt (programming, erp, stem, etc.)

### 3. Persist + Expose (`db/schema.hx`, `src/storage/`, `src/mcp_server/tools.py`)
- New nodes: `Skill`, `SkillStep`, `SkillVector`
- New edges: `HasStep`, `RequiresConcept`, `RequiresSkill`, `ProducesConcept`, `SkillDefinedIn`, `SkillHasEmbedding`
- Links prerequisite concepts to the existing concept graph by name
- MCP tools: `get_skill`, `get_skill_by_name`, `list_skills`, `search_skills`, `get_skill_prerequisites`

## CLI

```bash
# Phase 1 only — preview extraction (no LLM, no DB)
kidkazz skills extract <doc_id>

# Phase 1+2 — JSON with enrichment
kidkazz skills extract <doc_id> --enrich

# Full pipeline — extract + enrich + persist
kidkazz skills generate <doc_id> --profile programming --provider openai/gpt-4o-mini

# Dry-run (no DB writes)
kidkazz skills generate <doc_id> --dry-run
```

## Schema deployment
Requires `kidkazz db deploy` to apply the new schema (already run on the dev instance for this branch).

## Test plan
- [x] `PYTHONPATH=. pytest tests/test_skills.py -v` — 17 detection/assembly tests
- [x] `PYTHONPATH=. pytest tests/test_skill_synthesizer.py -v` — 6 LLM enrichment tests (Instructor mocked)
- [x] `PYTHONPATH=. pytest tests/test_skills_storage.py -v` — 9 storage + MCP formatter tests
- [x] Full suite: 1338 passing (no regressions)
- [x] Smoke test: `kidkazz skills extract` on real Helix-DB data — correctly returns 0 skills for the accounting textbook (no "How to" sections) without errors
- [ ] End-to-end test with a programming-style markdown (manual)

## Design notes
- **Why not merge raw steps into the LLM call?** LLM hallucination risk on code snippets is too high. Keeping phase B deterministic means `kubectl apply -f deploy.yaml` stays exactly as written.
- **Why separate `Skill` from `Summary`?** Summaries describe what a chapter teaches; skills describe what to execute. Complementary.
- **Why no cross-document skill merging in v1?** Same-skill-different-books is a v2 concern; the concept-merge pattern can be reused later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extract procedural "skills" from documents (detect boundaries, steps, code, expected outputs)
  * AI enrichment of skills with goal, difficulty, success criteria, prerequisites, produced concepts, and common-failure resolutions
  * Persisted skill storage with ordered steps, provenance, and optional embeddings for semantic search
  * Semantic skill search by embedding similarity and query-based ranking
  * CLI: new skills commands to extract, generate (persist), show, and list extracted skills
  * Server tools/APIs to fetch skills, steps, relationships, and perform semantic searches

* **Tests**
  * New unit and integration tests covering extraction, enrichment, storage, CLI, server formatting, and search

* **Bug Fixes**
  * Fixed missing trailing newline in a delete-related operation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->